### PR TITLE
fix: apply the saved brightness at boot instead of a hardcoded 204

### DIFF
--- a/src/app/app_boot.cpp
+++ b/src/app/app_boot.cpp
@@ -107,6 +107,9 @@ void appSetup() {
   backendLoadSettings();
 
   displayHardwareBegin(resetActivityTimer);
+  // Apply the stored brightness and arm the idle timer from a real
+  // millis() reading, not from 0.
+  displayPowerInit();
 
   I2C_EXT.begin(hw_pins::I2C_EXT_SDA, hw_pins::I2C_EXT_SCL, 100000);
 

--- a/src/hardware/display.cpp
+++ b/src/hardware/display.cpp
@@ -1,5 +1,6 @@
 #include "display.h"
 
+#include "app_config.h"
 #include "pins.h"
 
 #include <LovyanGFX.hpp>
@@ -33,6 +34,11 @@ public:
       cfg.invert=true; cfg.rgb_order=false;
       _panel.config(cfg); }
     { auto cfg = _light.config();
+      // invert stays false: GPIO45 drives the WT32-SC01 Plus backlight
+      // active-high, so duty 255 is full output. Flipping this to true does
+      // not brighten a dim panel, it blacks it out -- and it would also turn
+      // the backlight fully ON in deep sleep, where displayPrepareDeepSleep()
+      // asks for brightness 0.
       cfg.pin_bl=hw_pins::LCD_BACKLIGHT; cfg.invert=false;
       cfg.freq=44100; cfg.pwm_channel=7;
       _light.config(cfg); _panel.setLight(&_light); }
@@ -85,7 +91,12 @@ bool displayHardwareBegin(void (*touch_activity_cb)()) {
   i2c_touch.begin(hw_pins::TOUCH_SDA, hw_pins::TOUCH_SCL, 400000);
   tft.init();
   tft.setRotation(1);
-  tft.setBrightness(204);
+  // Full output until displayPowerInit() applies the user's saved level. This
+  // used to be a hardcoded 204, which meant every device ran the panel at 80%
+  // while the settings slider sat at its 255 default and reported full
+  // brightness -- the panel looked dim "at maximum" and dragging the slider to
+  // a value it already held fired no LV_EVENT_VALUE_CHANGED to correct it.
+  tft.setBrightness(BRIGHT_NORMAL_DEFAULT);
   tft.fillScreen(TFT_BLACK);
 
   lv_init();

--- a/src/hardware/display_power.cpp
+++ b/src/hardware/display_power.cpp
@@ -12,6 +12,15 @@
 static unsigned long last_activity_ms = 0;
 static bool is_dimmed = false;
 
+void displayPowerInit() {
+  last_activity_ms = millis();
+  is_dimmed = false;
+  // loadPrefs() has already restored bright_normal from NVS by this point;
+  // nothing else pushed it to the hardware, so the saved level only took
+  // effect after the first dim/wake cycle.
+  displaySetBrightness((uint8_t)bright_normal);
+}
+
 void resetActivityTimer() {
   last_activity_ms = millis();
   if (is_dimmed) {

--- a/src/hardware/display_power.h
+++ b/src/hardware/display_power.h
@@ -1,4 +1,8 @@
 #pragma once
 
+// Pushes the saved bright_normal to the panel and arms the idle timer.
+// Must run once after displayHardwareBegin(), otherwise the panel keeps
+// the init-time default and ignores the user's stored brightness.
+void displayPowerInit();
 void resetActivityTimer();
 void handlePowerManagement();


### PR DESCRIPTION
## The bug

`displayHardwareBegin()` sets the panel to a hardcoded `204` and nothing ever pushes `bright_normal` to the hardware. The ordering is what makes it bite:

```
app_boot.cpp:98    loadPrefs()             -> bright_normal = saved value (default 255)
app_boot.cpp:109   displayHardwareBegin()  -> tft.setBrightness(204)   <- overwrites it
```

The only other `setBrightness` call sites are both inside the dim path, guarded by `is_dimmed`, so on a freshly booted device the saved level never reaches the panel at all.

The settings slider renders from `bright_normal`, so a device at its 255 default shows a slider pegged at maximum while the backlight actually runs at 204 — **80% duty**. The slider cannot correct it either: dragging a knob that is already at 255 to 255 fires no `LV_EVENT_VALUE_CHANGED`. Waking from dim was the only path that ever put the panel at true maximum.

## Why it matters

That 20% is plainly visible. Stepping a WT32-SC01 Plus between 204 and 255 is an obvious change on the bench — unlike the 0.2% between LovyanGFX at 255 and driving the backlight pin to a hard DC rail, which is indistinguishable. So every device has been running a fifth dimmer than requested, on every boot.

## The fix

The panel initialises at `BRIGHT_NORMAL_DEFAULT`, and a new `displayPowerInit()` applies the stored level immediately after the hardware comes up. That call also arms `last_activity_ms` from a real `millis()` reading rather than leaving it at 0.

## Also in this PR

A comment recording **why the backlight `cfg.invert` flag must stay `false`**, because it is a tempting thing to flip when chasing a dim panel:

- The module datasheet (ZX3D50CE08S-USRC-4832, Tab.5) specifies `BL_PWM` on **GPIO45 as active high**.
- The schematic shows a plain S8050 NPN low-side switch with a 4R7 series resistor and no current regulation.
- Setting `invert=true` does not brighten a dim panel, it blacks it out — and it would turn the backlight **fully on** during deep sleep, where `displayPrepareDeepSleep()` asks for brightness 0.

## Testing

- `pio run -e wt32-sc01-plus` builds clean.
- Flashed to a physical WT32-SC01 Plus (ESP32-S3 rev v0.2) and verified on device: the saved brightness is applied at boot, and the 204 -> 255 change is clearly visible.
- Backlight behaviour was also checked against a raw `digitalWrite(45, HIGH)` reference and at 1 kHz vs 44.1 kHz PWM; all indistinguishable at level 255, confirming LovyanGFX already reaches full duty and that 255 is the hardware ceiling.
