### PR TITLE
refactor: move the UI palette into a runtime table

### DIFF
--- a/src/app/app_boot.cpp
+++ b/src/app/app_boot.cpp
@@ -25,6 +25,7 @@
 #include "ui/setup_welcome_screen.h"
 #include "ui/wifi_setup_screen.h"
 #include "lang.h"
+#include "ui/theme.h"
 
 // ============================================================
 //  CONNECT WIFI
@@ -70,7 +71,7 @@ void wifiConnect() {
       updateHeaderStatus();
       lv_label_set_text(lbl_spoolman_weight, T(STR_WAIT_SCAN_SM));
       lv_label_set_text(lbl_status, T(STR_WAIT_SCAN));
-      lv_obj_set_style_text_color(lbl_status, lv_color_hex(0xf0b838), 0);
+      lv_obj_set_style_text_color(lbl_status, tc(TH_WARNING), 0);
       lv_timer_handler();
       return;
   }
@@ -79,7 +80,7 @@ void wifiConnect() {
   updateHeaderStatus();
   lv_label_set_text(lbl_spoolman_weight, T(STR_NO_WIFI));
   lv_label_set_text(lbl_status, T(STR_WAIT_SCAN));
-  lv_obj_set_style_text_color(lbl_status, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_status, tc(TH_WARNING), 0);
   lv_timer_handler();
 }
 

--- a/src/app/app_loop.cpp
+++ b/src/app/app_loop.cpp
@@ -58,6 +58,7 @@
 #include "ui/tag_display.h"
 #include "ui/weight_format.h"
 #include "lang.h"
+#include "ui/theme.h"
 
 namespace {
 constexpr unsigned long NO_TAG_CLEAR_MS = 60000;
@@ -372,7 +373,7 @@ void appLoop() {
         strncpy(buf, T(STR_REMOTE_LINK_TIMEOUT), sizeof(buf) - 1);
         buf[sizeof(buf) - 1] = '\0';
         lv_label_set_text(lbl_status, buf);
-        lv_obj_set_style_text_color(lbl_status, lv_color_hex(0xf0b838), 0);
+        lv_obj_set_style_text_color(lbl_status, tc(TH_WARNING), 0);
       }
     } else if (tag_present && !isConfirmPopupOpen() &&
                !isSpoolFlowIdInputOpen() && !isSpoolFlowLinkEntryOpen()) {
@@ -448,9 +449,9 @@ void appLoop() {
   if (g_tag_displayed && millis() - g_tag_shown_ms > 10000) {
     g_tag_displayed = false;
     lv_label_set_text(lbl_nfc_dot, LV_SYMBOL_BULLET);
-    lv_obj_set_style_text_color(lbl_nfc_dot, lv_color_hex(0xf0b838), 0);  // yellow
+    lv_obj_set_style_text_color(lbl_nfc_dot, tc(TH_WARNING), 0);  // yellow
     lv_label_set_text(lbl_status, T(STR_WAIT_SCAN));
-    lv_obj_set_style_text_color(lbl_status, lv_color_hex(0xf0b838), 0);
+    lv_obj_set_style_text_color(lbl_status, tc(TH_WARNING), 0);
   }
 
   // NAU7802: read weight every 200ms and update labels.
@@ -508,7 +509,7 @@ void appLoop() {
         snprintf(sd_str, sizeof(sd_str), sm_diff >= 0 ? "+%.0f g" : "%.0f g", sm_diff);
         lv_label_set_text(lbl_raw_info, sd_str);
         lv_obj_set_style_text_color(lbl_raw_info,
-          sm_diff >= 0 ? lv_color_hex(0x40c080) : lv_color_hex(0xe04040), 0);
+          sm_diff >= 0 ? tc(TH_SUCCESS_TEXT) : lv_color_hex(0xe04040), 0);
       }
 
       // Live total (with spool)
@@ -526,7 +527,7 @@ void appLoop() {
         char b_str[16];
         fmtG(b_str, sizeof(b_str), ohne_beutel);
         lv_label_set_text(lbl_keys, b_str);
-        lv_obj_set_style_text_color(lbl_keys, lv_color_hex(0xf0b838), 0);  // same as scale netto
+        lv_obj_set_style_text_color(lbl_keys, tc(TH_WARNING), 0);  // same as scale netto
 
         // bag SM diff
         if (lbl_bag_sm_diff && sm_remaining > 0) {
@@ -535,7 +536,7 @@ void appLoop() {
           snprintf(bd_str, sizeof(bd_str), bag_diff >= 0 ? "+%.0f g" : "%.0f g", bag_diff);
           lv_label_set_text(lbl_bag_sm_diff, bd_str);
           lv_obj_set_style_text_color(lbl_bag_sm_diff,
-            bag_diff >= 0 ? lv_color_hex(0x40c080) : lv_color_hex(0xe04040), 0);
+            bag_diff >= 0 ? tc(TH_SUCCESS_TEXT) : lv_color_hex(0xe04040), 0);
         }
       }
     } else if (sm_found) {
@@ -570,7 +571,7 @@ void appLoop() {
         char wmbuf[48];
         snprintf(wmbuf, sizeof(wmbuf), "%s (A)", T(STR_BTN_WEIGHT));
         lv_label_set_text(lbl_weight_main_lbl, wmbuf);
-        lv_obj_set_style_text_color(lbl_weight_main_lbl, lv_color_hex(0x28d49a), 0);
+        lv_obj_set_style_text_color(lbl_weight_main_lbl, tc(TH_ACCENT), 0);
       }
     }
 
@@ -625,7 +626,7 @@ void appLoop() {
         char wmbuf[48];
         snprintf(wmbuf, sizeof(wmbuf), "%s (A)", T(STR_BTN_WEIGHT));
         lv_label_set_text(lbl_weight_main_lbl, wmbuf);
-        lv_obj_set_style_text_color(lbl_weight_main_lbl, lv_color_hex(0x28d49a), 0);
+        lv_obj_set_style_text_color(lbl_weight_main_lbl, tc(TH_ACCENT), 0);
       }
     }
   } else {
@@ -771,9 +772,9 @@ void appLoop() {
           nfc_retry_count = 0; nfc_absent_count = 0;
           last_bambu_retry_ms = 0;
           lv_label_set_text(lbl_nfc_dot, LV_SYMBOL_BULLET);
-          lv_obj_set_style_text_color(lbl_nfc_dot, lv_color_hex(0x28d49a), 0);
+          lv_obj_set_style_text_color(lbl_nfc_dot, tc(TH_ACCENT), 0);
           lv_label_set_text(lbl_status, T(STR_READING_TAG));
-          lv_obj_set_style_text_color(lbl_status, lv_color_hex(0x28d49a), 0);
+          lv_obj_set_style_text_color(lbl_status, tc(TH_ACCENT), 0);
           scanTag(uid, uidLen);
         } else if ((uuid_missing || contents_incomplete) && nfc_retry_count < NFC_MAX_RETRIES &&
                    millis() - last_bambu_retry_ms >= NFC_BAMBU_RETRY_BACKOFF_MS) {
@@ -785,16 +786,16 @@ void appLoop() {
             nfc_retry_count,
             NFC_MAX_RETRIES);
           lv_label_set_text(lbl_nfc_dot, LV_SYMBOL_BULLET);
-          lv_obj_set_style_text_color(lbl_nfc_dot, lv_color_hex(0x28d49a), 0);
+          lv_obj_set_style_text_color(lbl_nfc_dot, tc(TH_ACCENT), 0);
           lv_label_set_text(lbl_status, T(STR_READING_TAG));
-          lv_obj_set_style_text_color(lbl_status, lv_color_hex(0x28d49a), 0);
+          lv_obj_set_style_text_color(lbl_status, tc(TH_ACCENT), 0);
           scanTag(uid, uidLen);
         } else {
           if ((uuid_missing || contents_incomplete) && nfc_retry_count >= NFC_MAX_RETRIES) {
             lv_label_set_text(lbl_nfc_dot, LV_SYMBOL_BULLET);
-            lv_obj_set_style_text_color(lbl_nfc_dot, lv_color_hex(0xf0b838), 0);
+            lv_obj_set_style_text_color(lbl_nfc_dot, tc(TH_WARNING), 0);
             lv_label_set_text(lbl_status, T(STR_WAIT_SCAN));
-            lv_obj_set_style_text_color(lbl_status, lv_color_hex(0xf0b838), 0);
+            lv_obj_set_style_text_color(lbl_status, tc(TH_WARNING), 0);
           } else {
             // tray_uuid present — query Spoolman if not done yet
             if (!isSpoolFlowIdInputOpen() && strcmp(g_tag.uid_str, spoolman_queried_uid) != 0 && strlen(g_tag.tray_uuid) == 32) {
@@ -811,10 +812,10 @@ void appLoop() {
               (void)link_tag_first_seen_ms;
             }
             lv_label_set_text(lbl_nfc_dot, LV_SYMBOL_BULLET);
-            lv_obj_set_style_text_color(lbl_nfc_dot, lv_color_hex(0x28d49a), 0);
+            lv_obj_set_style_text_color(lbl_nfc_dot, tc(TH_ACCENT), 0);
             { char sb[48]; backendText(sm_found ? T(STR_TAG_FOUND) : T(STR_NOT_IN_SPOOLMAN), sb, sizeof(sb)); lv_label_set_text(lbl_status, sb); }
             lv_obj_set_style_text_color(lbl_status,
-              sm_found ? lv_color_hex(0x28d49a) : lv_color_hex(0xf0b838), 0);
+              sm_found ? tc(TH_ACCENT) : tc(TH_WARNING), 0);
           }
         }
 
@@ -835,7 +836,7 @@ void appLoop() {
         if (uid_changed_ntag_log) logSDf("NFC: NTAG UID=%s", uid_str);
 
         lv_label_set_text(lbl_nfc_dot, LV_SYMBOL_BULLET);
-        lv_obj_set_style_text_color(lbl_nfc_dot, lv_color_hex(0x28d49a), 0);
+        lv_obj_set_style_text_color(lbl_nfc_dot, tc(TH_ACCENT), 0);
 
         bool uid_changed_ntag = (strcmp(uid_str, g_tag.uid_str) != 0);
 
@@ -859,7 +860,7 @@ void appLoop() {
         if (lbl_dried_sym) lv_obj_add_flag(lbl_dried_sym, LV_OBJ_FLAG_HIDDEN);
           lv_obj_set_style_bg_color(lbl_color_swatch, lv_color_hex(0x333333), 0);
           lv_label_set_text(lbl_status, T(STR_READING_TAG));
-          lv_obj_set_style_text_color(lbl_status, lv_color_hex(0x28d49a), 0);
+          lv_obj_set_style_text_color(lbl_status, tc(TH_ACCENT), 0);
           lv_timer_handler();
 
           if (wifi_ok && !isSpoolFlowIdInputOpen()) {
@@ -875,14 +876,14 @@ void appLoop() {
               link_popup_dismissed = false;
             } else {
               lv_label_set_text(lbl_status, T(STR_TAG_FOUND));
-              lv_obj_set_style_text_color(lbl_status, lv_color_hex(0x28d49a), 0);
+              lv_obj_set_style_text_color(lbl_status, tc(TH_ACCENT), 0);
               strncpy(g_tag.tray_uuid, uid_str, sizeof(g_tag.tray_uuid)-1);
               g_tag.tray_uuid[sizeof(g_tag.tray_uuid)-1] = '\0';
               updateLinkButton();
             }
           } else {
             lv_label_set_text(lbl_status, T(STR_TAG_FOUND));
-            lv_obj_set_style_text_color(lbl_status, lv_color_hex(0x28d49a), 0);
+            lv_obj_set_style_text_color(lbl_status, tc(TH_ACCENT), 0);
           }
         } else {
           // Same UID — show popup after delay if not dismissed
@@ -890,7 +891,7 @@ void appLoop() {
           (void)link_tag_first_seen_ms;
           { char sb[48]; backendText(sm_found ? T(STR_TAG_FOUND) : T(STR_NOT_IN_SPOOLMAN), sb, sizeof(sb)); lv_label_set_text(lbl_status, sb); }
           lv_obj_set_style_text_color(lbl_status,
-            sm_found ? lv_color_hex(0x28d49a) : lv_color_hex(0xf0b838), 0);
+            sm_found ? tc(TH_ACCENT) : tc(TH_WARNING), 0);
         }
 
       } else {
@@ -929,9 +930,9 @@ void appLoop() {
           link_popup_dismissed = false;   // Reset flag → next spool can show popup
           link_tag_first_seen_ms = 0;
           lv_label_set_text(lbl_nfc_dot, LV_SYMBOL_BULLET);
-          lv_obj_set_style_text_color(lbl_nfc_dot, lv_color_hex(0xf0b838), 0);
+          lv_obj_set_style_text_color(lbl_nfc_dot, tc(TH_WARNING), 0);
           lv_label_set_text(lbl_status, T(STR_WAIT_SCAN));
-          lv_obj_set_style_text_color(lbl_status, lv_color_hex(0xf0b838), 0);
+          lv_obj_set_style_text_color(lbl_status, tc(TH_WARNING), 0);
           // Auto location popup: if enabled, spool is linked, and not shown for this spool yet
           // Debounce: only trigger after 1500ms — avoids spurious remove during NTAG read
           if (g_auto_loc_popup && sm_found && sm_id > 0 && wifi_ok && g_loc_popup_shown_for_id != sm_id) {

--- a/src/ui/backend_screen.cpp
+++ b/src/ui/backend_screen.cpp
@@ -14,6 +14,7 @@
 #include "extra_fields_screen.h"
 #include "ota_browser.h"
 #include "ui_common.h"
+#include "theme.h"
 
 // Switching the mode has to happen outside this screen's own event callback,
 // otherwise the callback would delete the button it is currently running on.
@@ -42,17 +43,17 @@ static lv_obj_t* addNavRow(lv_obj_t *parent, int y, const char *title,
   lv_obj_t *row = lv_btn_create(parent);
   lv_obj_set_size(row, 448, 56);
   lv_obj_set_pos(row, 16, y);
-  lv_obj_set_style_bg_color(row, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(row, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(row, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(row, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(row, 10, 0);
   lv_obj_set_style_shadow_width(row, 0, 0);
   lv_obj_set_style_border_width(row, 1, 0);
-  lv_obj_set_style_border_color(row, lv_color_hex(0x1a3050), 0);
+  lv_obj_set_style_border_color(row, tc(TH_BORDER), 0);
   lv_obj_add_event_cb(row, cb, LV_EVENT_CLICKED, NULL);
 
   lv_obj_t *l = lv_label_create(row);
   lv_label_set_text(l, title);
-  lv_obj_set_style_text_color(l, lv_color_hex(0xe8f0ff), 0);
+  lv_obj_set_style_text_color(l, tc(TH_TEXT_BRIGHT), 0);
   lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(l, LV_ALIGN_LEFT_MID, 8, -11);
 
@@ -64,7 +65,7 @@ static lv_obj_t* addNavRow(lv_obj_t *parent, int y, const char *title,
 
   lv_obj_t *a = lv_label_create(row);
   lv_label_set_text(a, LV_SYMBOL_RIGHT);
-  lv_obj_set_style_text_color(a, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(a, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(a, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(a, LV_ALIGN_RIGHT_MID, -10, 0);
   return row;
@@ -90,7 +91,7 @@ static void addCredentialsRow(lv_obj_t *parent, int y,
 
     lv_obj_t *l = lv_label_create(parent);
     lv_label_set_text(l, lbl_buf);
-    lv_obj_set_style_text_color(l, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(l, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_pos(l, x, y);
 
@@ -101,7 +102,7 @@ static void addCredentialsRow(lv_obj_t *parent, int y,
 
     lv_obj_t *v = lv_label_create(parent);
     lv_label_set_text(v, val_buf);
-    lv_obj_set_style_text_color(v, lv_color_hex(present[i] ? 0x40c080 : 0xf0b838), 0);
+    lv_obj_set_style_text_color(v, lv_color_hex(present[i] ? g_theme[TH_SUCCESS_TEXT] : g_theme[TH_WARNING]), 0);
     lv_obj_set_style_text_font(v, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_pos(v, x, y + 22);
   }
@@ -123,15 +124,15 @@ void buildBackendScreen() {
   if (setup_active) {
     lv_obj_t *lbl_title = lv_label_create(scr_backend);
     lv_label_set_text(lbl_title, buf_title);
-    lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
     lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 12);
 
     lv_obj_t *btn_x = lv_btn_create(scr_backend);
     lv_obj_set_size(btn_x, 44, 44);
     lv_obj_align(btn_x, LV_ALIGN_TOP_RIGHT, -4, 2);
-    lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x3a1010), 0);
-    lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x602020), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_BG), 0);
+    lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_x, 8, 0);
     lv_obj_set_style_shadow_width(btn_x, 0, 0);
     lv_obj_set_style_border_width(btn_x, 0, 0);
@@ -141,7 +142,7 @@ void buildBackendScreen() {
     }, LV_EVENT_CLICKED, NULL);
     lv_obj_t *lbl_x = lv_label_create(btn_x);
     lv_label_set_text(lbl_x, LV_SYMBOL_CLOSE);
-    lv_obj_set_style_text_color(lbl_x, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_x, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(lbl_x, &lv_font_montserrat_ext_18, 0);
     lv_obj_center(lbl_x);
   } else {
@@ -167,16 +168,16 @@ void buildBackendScreen() {
     lv_obj_t *b = lv_btn_create(scr_backend);
     lv_obj_set_size(b, SEG_W, SEG_H);
     lv_obj_set_pos(b, segs[i].x, SEG_Y);
-    lv_obj_set_style_bg_color(b, lv_color_hex(active ? 0x14402e : 0x0a1828), 0);
-    lv_obj_set_style_bg_color(b, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(b, lv_color_hex(active ? 0x14402e : g_theme[TH_SURFACE]), 0);
+    lv_obj_set_style_bg_color(b, tc(TH_SURFACE_2), LV_STATE_PRESSED);
     lv_obj_set_style_radius(b, 10, 0);
     lv_obj_set_style_shadow_width(b, 0, 0);
     lv_obj_set_style_border_width(b, active ? 2 : 1, 0);
-    lv_obj_set_style_border_color(b, lv_color_hex(active ? 0x28d49a : 0x1a2840), 0);
+    lv_obj_set_style_border_color(b, lv_color_hex(active ? g_theme[TH_ACCENT] : g_theme[TH_SURFACE_3]), 0);
 
     lv_obj_t *l = lv_label_create(b);
     lv_label_set_text(l, segs[i].name);
-    lv_obj_set_style_text_color(l, lv_color_hex(active ? 0x28d49a : 0x8098b8), 0);
+    lv_obj_set_style_text_color(l, lv_color_hex(active ? g_theme[TH_ACCENT] : 0x8098b8), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_18, 0);
     lv_obj_center(l);
 
@@ -201,7 +202,7 @@ void buildBackendScreen() {
 
     lv_obj_t *hint = lv_label_create(scr_backend);
     lv_label_set_text(hint, buf_hint);
-    lv_obj_set_style_text_color(hint, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(hint, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(hint, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(hint, LV_TEXT_ALIGN_CENTER, 0);
     lv_label_set_long_mode(hint, LV_LABEL_LONG_WRAP);
@@ -211,8 +212,8 @@ void buildBackendScreen() {
     lv_obj_t *btn_next = lv_btn_create(scr_backend);
     lv_obj_set_size(btn_next, 200, 48);
     lv_obj_align(btn_next, LV_ALIGN_BOTTOM_MID, 0, -20);
-    lv_obj_set_style_bg_color(btn_next, lv_color_hex(0x1a3020), 0);
-    lv_obj_set_style_bg_color(btn_next, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_next, tc(TH_OK_BG), 0);
+    lv_obj_set_style_bg_color(btn_next, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_next, 8, 0);
     lv_obj_set_style_shadow_width(btn_next, 0, 0);
     lv_obj_set_style_border_width(btn_next, 0, 0);
@@ -224,7 +225,7 @@ void buildBackendScreen() {
     char next_buf[32];
     snprintf(next_buf, sizeof(next_buf), "%s  " LV_SYMBOL_RIGHT, T(STR_BTN_NEXT));
     lv_label_set_text(lbl_next, next_buf);
-    lv_obj_set_style_text_color(lbl_next, lv_color_hex(0x40c080), 0);
+    lv_obj_set_style_text_color(lbl_next, tc(TH_SUCCESS_TEXT), 0);
     lv_obj_set_style_text_font(lbl_next, &lv_font_montserrat_ext_16, 0);
     lv_obj_center(lbl_next);
     return;
@@ -246,7 +247,7 @@ void buildBackendScreen() {
     const bool port_missing = h && h[0] && !strchr(h, ':');
 
     addNavRow(scr_backend, 122, buf_addr, host_buf,
-              port_missing ? 0xf0b838 : 0x28d49a,
+              port_missing ? g_theme[TH_WARNING] : g_theme[TH_ACCENT],
               [](lv_event_t *e) {
                 logSD("BTN: Backend -> Address");
                 show_spoolman_pending = true;
@@ -262,7 +263,7 @@ void buildBackendScreen() {
   if (!is_filaman) {
     char buf_ef[40];
     backendText(T(STR_EXTRA_FIELDS_TITLE), buf_ef, sizeof(buf_ef));
-    addNavRow(scr_backend, 186, buf_ef, "tag, last_dried", 0x4a6fa0,
+    addNavRow(scr_backend, 186, buf_ef, "tag, last_dried", g_theme[TH_TEXT_MUTED],
               [](lv_event_t *e) {
                 logSD("BTN: Backend -> Extra Fields");
                 showExtraFieldsScreen(false);
@@ -285,12 +286,12 @@ void buildBackendScreen() {
     lv_obj_t *btn_opts = lv_btn_create(scr_backend);
     lv_obj_set_size(btn_opts, 216, 44);
     lv_obj_set_pos(btn_opts, 16, 244);
-    lv_obj_set_style_bg_color(btn_opts, lv_color_hex(0x0a1e30), 0);
-    lv_obj_set_style_bg_color(btn_opts, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_opts, tc(TH_TILE_BG), 0);
+    lv_obj_set_style_bg_color(btn_opts, tc(TH_BORDER), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_opts, 8, 0);
     lv_obj_set_style_shadow_width(btn_opts, 0, 0);
     lv_obj_set_style_border_width(btn_opts, 1, 0);
-    lv_obj_set_style_border_color(btn_opts, lv_color_hex(0x1a3060), 0);
+    lv_obj_set_style_border_color(btn_opts, tc(TH_SURFACE_2), 0);
     lv_obj_add_event_cb(btn_opts, [](lv_event_t *e) {
       logSD("BTN: Backend -> FilaMan options");
       show_filaman_options_pending = true;
@@ -299,19 +300,19 @@ void buildBackendScreen() {
     { char ob[40];
       snprintf(ob, sizeof(ob), "%s  " LV_SYMBOL_RIGHT, T(STR_BTN_MORE_OPTIONS));
       lv_label_set_text(lbl_opts, ob); }
-    lv_obj_set_style_text_color(lbl_opts, lv_color_hex(0xc8d8f0), 0);
+    lv_obj_set_style_text_color(lbl_opts, tc(TH_TEXT), 0);
     lv_obj_set_style_text_font(lbl_opts, &lv_font_montserrat_ext_16, 0);
     lv_obj_center(lbl_opts);
 
     lv_obj_t *btn_web = lv_btn_create(scr_backend);
     lv_obj_set_size(btn_web, 216, 44);
     lv_obj_set_pos(btn_web, 248, 244);
-    lv_obj_set_style_bg_color(btn_web, lv_color_hex(0x0a1e30), 0);
-    lv_obj_set_style_bg_color(btn_web, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_web, tc(TH_TILE_BG), 0);
+    lv_obj_set_style_bg_color(btn_web, tc(TH_BORDER), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_web, 8, 0);
     lv_obj_set_style_shadow_width(btn_web, 0, 0);
     lv_obj_set_style_border_width(btn_web, 1, 0);
-    lv_obj_set_style_border_color(btn_web, lv_color_hex(0x1a3060), 0);
+    lv_obj_set_style_border_color(btn_web, tc(TH_SURFACE_2), 0);
     lv_obj_add_event_cb(btn_web, [](lv_event_t *e) {
       logSD("BTN: Backend -> Web interface");
       // Safe to call directly: this only hides the backend screen, the one
@@ -323,7 +324,7 @@ void buildBackendScreen() {
     char buf_web[40];
     snprintf(buf_web, sizeof(buf_web), "%s  " LV_SYMBOL_RIGHT, T(STR_BTN_WEB_SETUP));
     lv_label_set_text(lbl_web, buf_web);
-    lv_obj_set_style_text_color(lbl_web, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(lbl_web, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(lbl_web, &lv_font_montserrat_ext_16, 0);
     lv_obj_center(lbl_web);
   }

--- a/src/ui/bag_screen.cpp
+++ b/src/ui/bag_screen.cpp
@@ -12,6 +12,7 @@
 #include "lang.h"
 #include "scale_menu.h"
 #include "ui_common.h"
+#include "theme.h"
 
 
 
@@ -30,7 +31,7 @@ void buildBagScreen() {
   lv_obj_set_style_border_width(scr_bag, 0, 0);
   lv_obj_set_style_pad_all(scr_bag, 0, 0);
   lv_obj_clear_flag(scr_bag, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr_bag, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_bag, tc(TH_BG), 0);
 
   lbl_bag_display = nullptr;
   lbl_bag_result_global = nullptr;
@@ -47,14 +48,14 @@ void buildBagScreen() {
 
   lv_obj_t *lbl_desc = lv_label_create(scr_bag);
   lv_label_set_text(lbl_desc, T(STR_BAG_DESC));
-  lv_obj_set_style_text_color(lbl_desc, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_desc, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_desc, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(lbl_desc, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_desc, LV_ALIGN_TOP_MID, 0, 58);
 
   lbl_bag_result_global = lv_label_create(scr_bag);
   lv_label_set_text(lbl_bag_result_global, "");
-  lv_obj_set_style_text_color(lbl_bag_result_global, lv_color_hex(0x40c080), 0);
+  lv_obj_set_style_text_color(lbl_bag_result_global, tc(TH_SUCCESS_TEXT), 0);
   lv_obj_set_style_text_font(lbl_bag_result_global, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_bag_result_global, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_bag_result_global, LV_ALIGN_TOP_MID, 0, 78);
@@ -62,8 +63,8 @@ void buildBagScreen() {
   lv_obj_t *input_box_b = lv_obj_create(scr_bag);
   lv_obj_set_size(input_box_b, 260, 38);
   lv_obj_align(input_box_b, LV_ALIGN_TOP_MID, 0, 98);
-  lv_obj_set_style_bg_color(input_box_b, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_border_color(input_box_b, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_bg_color(input_box_b, tc(TH_SURFACE), 0);
+  lv_obj_set_style_border_color(input_box_b, tc(TH_ACCENT), 0);
   lv_obj_set_style_border_width(input_box_b, 1, 0);
   lv_obj_set_style_radius(input_box_b, 6, 0);
   lv_obj_set_style_pad_all(input_box_b, 0, 0);
@@ -71,7 +72,7 @@ void buildBagScreen() {
 
   lbl_bag_display = lv_label_create(input_box_b);
   lv_label_set_text(lbl_bag_display, bag_input);
-  lv_obj_set_style_text_color(lbl_bag_display, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_bag_display, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_bag_display, &lv_font_montserrat_ext_20, 0);
   lv_obj_set_style_text_align(lbl_bag_display, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_center(lbl_bag_display);
@@ -87,15 +88,15 @@ void buildBagScreen() {
     lv_obj_t *btn = lv_btn_create(scr_bag);
     lv_obj_set_size(btn, NP_W, NP_H);
     lv_obj_set_pos(btn, NP_PAD_X + col*(NP_W+NP_GAP), NP_START_Y + row*(NP_H+NP_GAP));
-    lv_obj_set_style_bg_color(btn, lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_bg_color(btn, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn, tc(TH_SURFACE), 0);
+    lv_obj_set_style_bg_color(btn, tc(TH_SURFACE_2), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn, 6, 0);
     lv_obj_set_style_shadow_width(btn, 0, 0);
     lv_obj_set_style_border_width(btn, 1, 0);
-    lv_obj_set_style_border_color(btn, lv_color_hex(0x1a2840), 0);
+    lv_obj_set_style_border_color(btn, tc(TH_SURFACE_3), 0);
     lv_obj_t *lbl = lv_label_create(btn);
     lv_label_set_text(lbl, np_labels_b[i]);
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_16, 0);
     lv_obj_center(lbl);
     lv_obj_add_event_cb(btn, [](lv_event_t *e) {
@@ -115,12 +116,12 @@ void buildBagScreen() {
   lv_obj_t *btn_del_b = lv_btn_create(scr_bag);
   lv_obj_set_size(btn_del_b, bw5_b, NP_H);
   lv_obj_set_pos(btn_del_b, NP_PAD_X, by5_b);
-  lv_obj_set_style_bg_color(btn_del_b, lv_color_hex(0x1a2030), 0);
+  lv_obj_set_style_bg_color(btn_del_b, tc(TH_SURFACE_DARK), 0);
   lv_obj_set_style_bg_color(btn_del_b, lv_color_hex(0x2a3040), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_del_b, 6, 0);
   lv_obj_set_style_shadow_width(btn_del_b, 0, 0);
   lv_obj_set_style_border_width(btn_del_b, 1, 0);
-  lv_obj_set_style_border_color(btn_del_b, lv_color_hex(0x1a2840), 0);
+  lv_obj_set_style_border_color(btn_del_b, tc(TH_SURFACE_3), 0);
   lv_obj_add_event_cb(btn_del_b, [](lv_event_t *e) {
     if (!lbl_bag_display) return;
     int len = strlen(bag_input);
@@ -129,19 +130,19 @@ void buildBagScreen() {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_del_b = lv_label_create(btn_del_b);
   lv_label_set_text(lbl_del_b, LV_SYMBOL_BACKSPACE);
-  lv_obj_set_style_text_color(lbl_del_b, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_del_b, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_del_b, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_del_b);
 
   lv_obj_t *btn_ok_b = lv_btn_create(scr_bag);
   lv_obj_set_size(btn_ok_b, bw5_b, NP_H);
   lv_obj_set_pos(btn_ok_b, NP_PAD_X + bw5_b + NP_GAP, by5_b);
-  lv_obj_set_style_bg_color(btn_ok_b, lv_color_hex(0x1a3020), 0);
-  lv_obj_set_style_bg_color(btn_ok_b, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_ok_b, tc(TH_OK_BG), 0);
+  lv_obj_set_style_bg_color(btn_ok_b, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_ok_b, 6, 0);
   lv_obj_set_style_shadow_width(btn_ok_b, 0, 0);
   lv_obj_set_style_border_width(btn_ok_b, 1, 0);
-  lv_obj_set_style_border_color(btn_ok_b, lv_color_hex(0x2a5030), 0);
+  lv_obj_set_style_border_color(btn_ok_b, tc(TH_SUCCESS_BG), 0);
   lv_obj_add_event_cb(btn_ok_b, [](lv_event_t *e) {
     if (!lbl_bag_result_global) return;
     float w = atof(bag_input);
@@ -156,7 +157,7 @@ void buildBagScreen() {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_ok2_b = lv_label_create(btn_ok_b);
   lv_label_set_text(lbl_ok2_b, T(STR_BTN_SAVE));
-  lv_obj_set_style_text_color(lbl_ok2_b, lv_color_hex(0x40c080), 0);
+  lv_obj_set_style_text_color(lbl_ok2_b, tc(TH_SUCCESS_TEXT), 0);
   lv_obj_set_style_text_font(lbl_ok2_b, &lv_font_montserrat_ext_14, 0);
   lv_obj_center(lbl_ok2_b);
 }

--- a/src/ui/cal_reminder_screen.cpp
+++ b/src/ui/cal_reminder_screen.cpp
@@ -10,6 +10,7 @@
 #include "hardware/sd_logger.h"
 #include "lang.h"
 #include "ui_common.h"
+#include "theme.h"
 
 
 
@@ -55,7 +56,7 @@ void buildCalReminderScreen() {
   lv_obj_set_style_border_width(scr_cal_reminder, 0, 0);
   lv_obj_set_style_pad_all(scr_cal_reminder, 0, 0);
   lv_obj_clear_flag(scr_cal_reminder, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr_cal_reminder, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_cal_reminder, tc(TH_BG), 0);
 
   // Static buffers — must outlive the function since LVGL holds pointers to them
   static char buf_title[48], buf_msg[256], buf_later[32], buf_now[48];
@@ -68,7 +69,7 @@ void buildCalReminderScreen() {
   // Title
   lv_obj_t *lbl_title = lv_label_create(scr_cal_reminder);
   lv_label_set_text(lbl_title, buf_title);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 20);
 
@@ -78,14 +79,14 @@ void buildCalReminderScreen() {
   // Icon
   lv_obj_t *lbl_icon = lv_label_create(scr_cal_reminder);
   lv_label_set_text(lbl_icon, LV_SYMBOL_EDIT);
-  lv_obj_set_style_text_color(lbl_icon, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_icon, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_icon, &lv_font_montserrat_ext_24, 0);
   lv_obj_align(lbl_icon, LV_ALIGN_TOP_MID, 0, 52);
 
   // Message
   lv_obj_t *lbl_msg = lv_label_create(scr_cal_reminder);
   lv_label_set_text(lbl_msg, buf_msg);
-  lv_obj_set_style_text_color(lbl_msg, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_msg, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_msg, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_msg, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_msg, LV_LABEL_LONG_WRAP);
@@ -96,18 +97,18 @@ void buildCalReminderScreen() {
   lv_obj_t *btn_got = lv_btn_create(scr_cal_reminder);
   lv_obj_set_size(btn_got, 280, 48);
   lv_obj_align(btn_got, LV_ALIGN_BOTTOM_MID, 0, -20);
-  lv_obj_set_style_bg_color(btn_got, lv_color_hex(0x1a3020), 0);
-  lv_obj_set_style_bg_color(btn_got, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_got, tc(TH_OK_BG), 0);
+  lv_obj_set_style_bg_color(btn_got, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_got, 8, 0);
   lv_obj_set_style_shadow_width(btn_got, 0, 0);
   lv_obj_set_style_border_width(btn_got, 1, 0);
-  lv_obj_set_style_border_color(btn_got, lv_color_hex(0x2a5030), 0);
+  lv_obj_set_style_border_color(btn_got, tc(TH_SUCCESS_BG), 0);
   lv_obj_add_event_cb(btn_got, [](lv_event_t *e) {
     showMainScreen();
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_got = lv_label_create(btn_got);
   lv_label_set_text(lbl_got, buf_later);
-  lv_obj_set_style_text_color(lbl_got, lv_color_hex(0x40c080), 0);
+  lv_obj_set_style_text_color(lbl_got, tc(TH_SUCCESS_TEXT), 0);
   lv_obj_set_style_text_font(lbl_got, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_got);
 }

--- a/src/ui/confirm_popup.cpp
+++ b/src/ui/confirm_popup.cpp
@@ -11,6 +11,7 @@
 #include "services/spoolman_actions.h"
 #include "dried_action.h"
 #include "lang.h"
+#include "theme.h"
 
 
 static lv_obj_t *confirm_popup = nullptr;
@@ -34,7 +35,7 @@ void showConfirmPopup(const char* msg, int action) {
   confirm_popup = lv_obj_create(lv_scr_act());
   lv_obj_set_size(confirm_popup, 480, 320);
   lv_obj_set_pos(confirm_popup, 0, 0);
-  lv_obj_set_style_bg_color(confirm_popup, lv_color_hex(0x000000), 0);
+  lv_obj_set_style_bg_color(confirm_popup, tc(TH_BLACK), 0);
   lv_obj_set_style_bg_opa(confirm_popup, LV_OPA_70, 0);
   lv_obj_set_style_border_width(confirm_popup, 0, 0);
   lv_obj_set_style_radius(confirm_popup, 0, 0);
@@ -50,7 +51,7 @@ void showConfirmPopup(const char* msg, int action) {
 
   lv_obj_t *lbl_q = lv_label_create(box);
   lv_label_set_text(lbl_q, msg);
-  lv_obj_set_style_text_color(lbl_q, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_q, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_q, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_q, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_q, LV_LABEL_LONG_WRAP);
@@ -165,7 +166,7 @@ void showConfirmPopup(const char* msg, int action) {
     lv_obj_set_size(btn4, BW2, H_ROW2);
     lv_obj_set_pos(btn4, XR, Y2);
     lv_obj_set_style_bg_color(btn4, lv_color_hex(0x1a2a40), 0);
-    lv_obj_set_style_bg_color(btn4, lv_color_hex(0x2a4060), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn4, tc(TH_TEXT_DIM), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn4, 8, 0);
     lv_obj_set_style_shadow_width(btn4, 0, 0);
     lv_obj_add_event_cb(btn4, [](lv_event_t *e) {
@@ -176,7 +177,7 @@ void showConfirmPopup(const char* msg, int action) {
       lv_obj_t *popup = lv_obj_create(lv_scr_act());
       lv_obj_set_size(popup, 480, 320);
       lv_obj_set_pos(popup, 0, 0);
-      lv_obj_set_style_bg_color(popup, lv_color_hex(0x0a1020), 0);
+      lv_obj_set_style_bg_color(popup, tc(TH_BG), 0);
       lv_obj_set_style_bg_opa(popup, LV_OPA_COVER, 0);
       lv_obj_set_style_border_width(popup, 0, 0);
       lv_obj_set_style_pad_all(popup, 0, 0);
@@ -187,7 +188,7 @@ void showConfirmPopup(const char* msg, int action) {
       char title_buf[48];
       snprintf(title_buf, sizeof(title_buf), T(STR_SPOOL_WEIGHT_TITLE), w);
       lv_label_set_text(title, title_buf);
-      lv_obj_set_style_text_color(title, lv_color_hex(0x28d49a), 0);
+      lv_obj_set_style_text_color(title, tc(TH_ACCENT), 0);
       lv_obj_set_style_text_font(title, &lv_font_montserrat_ext_14, 0);
       lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 10);
 
@@ -198,7 +199,7 @@ void showConfirmPopup(const char* msg, int action) {
       lv_obj_set_style_radius(b1, 8, 0); lv_obj_set_style_shadow_width(b1, 0, 0);
       { lv_obj_t *l = lv_label_create(b1);
         lv_label_set_text(l, T(STR_BTN_THIS_SPOOL));
-        lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
+        lv_obj_set_style_text_color(l, tc(TH_TEXT), 0);
         lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
         lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
         lv_obj_center(l); }
@@ -214,7 +215,7 @@ void showConfirmPopup(const char* msg, int action) {
       lv_obj_set_style_radius(b2, 8, 0); lv_obj_set_style_shadow_width(b2, 0, 0);
       { lv_obj_t *l = lv_label_create(b2);
         lv_label_set_text(l, T(STR_BTN_THIS_FILAMENT));
-        lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
+        lv_obj_set_style_text_color(l, tc(TH_TEXT), 0);
         lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
         lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
         lv_obj_center(l); }
@@ -230,7 +231,7 @@ void showConfirmPopup(const char* msg, int action) {
       lv_obj_set_style_radius(b3, 8, 0); lv_obj_set_style_shadow_width(b3, 0, 0);
       { lv_obj_t *l = lv_label_create(b3);
         lv_label_set_text(l, T(STR_BTN_THIS_VENDOR));
-        lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
+        lv_obj_set_style_text_color(l, tc(TH_TEXT), 0);
         lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
         lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
         lv_obj_center(l); }
@@ -242,11 +243,11 @@ void showConfirmPopup(const char* msg, int action) {
       // Button 4: cancel
       lv_obj_t *b4 = lv_btn_create(popup);
       lv_obj_set_size(b4, 460, 40); lv_obj_set_pos(b4, 10, 256);
-      lv_obj_set_style_bg_color(b4, lv_color_hex(0x3a1010), 0);
+      lv_obj_set_style_bg_color(b4, tc(TH_DANGER_BG), 0);
       lv_obj_set_style_radius(b4, 8, 0); lv_obj_set_style_shadow_width(b4, 0, 0);
       { lv_obj_t *l = lv_label_create(b4);
         lv_label_set_text(l, T(STR_CANCEL));
-        lv_obj_set_style_text_color(l, lv_color_hex(0xff8080), 0);
+        lv_obj_set_style_text_color(l, tc(TH_DANGER_TEXT), 0);
         lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_14, 0);
         lv_obj_center(l); }
       lv_obj_add_event_cb(b4, [](lv_event_t *e) {
@@ -269,10 +270,10 @@ void showConfirmPopup(const char* msg, int action) {
     lv_obj_t *btn5 = lv_btn_create(box);
     lv_obj_set_size(btn5, BW2, H_ROW3);
     lv_obj_set_pos(btn5, XL, Y3);
-    lv_obj_set_style_bg_color(btn5, g_auto_weight ? lv_color_hex(0x1a3020) : lv_color_hex(0x101820), 0);
-    lv_obj_set_style_bg_color(btn5, g_auto_weight ? lv_color_hex(0x2a5030) : lv_color_hex(0x1a2a38), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn5, g_auto_weight ? tc(TH_OK_BG) : lv_color_hex(0x101820), 0);
+    lv_obj_set_style_bg_color(btn5, g_auto_weight ? tc(TH_SUCCESS_BG) : lv_color_hex(0x1a2a38), LV_STATE_PRESSED);
     lv_obj_set_style_border_width(btn5, 1, 0);
-    lv_obj_set_style_border_color(btn5, g_auto_weight ? lv_color_hex(0x28d49a) : lv_color_hex(0x1a2840), 0);
+    lv_obj_set_style_border_color(btn5, g_auto_weight ? tc(TH_ACCENT) : tc(TH_SURFACE_3), 0);
     lv_obj_set_style_radius(btn5, 8, 0);
     lv_obj_set_style_shadow_width(btn5, 0, 0);
     lv_obj_add_event_cb(btn5, [](lv_event_t *e) {
@@ -289,7 +290,7 @@ void showConfirmPopup(const char* msg, int action) {
           char wmbuf[40];
           strncpy(wmbuf, T(STR_BTN_WEIGHT), sizeof(wmbuf)-1); wmbuf[sizeof(wmbuf)-1] = '\0';
           lv_label_set_text(lbl_weight_main_lbl, wmbuf);
-          lv_obj_set_style_text_color(lbl_weight_main_lbl, lv_color_hex(0x40c080), 0);
+          lv_obj_set_style_text_color(lbl_weight_main_lbl, tc(TH_SUCCESS_TEXT), 0);
         }
         closeConfirmPopup();
       } else {
@@ -300,7 +301,7 @@ void showConfirmPopup(const char* msg, int action) {
         lv_obj_t *apop = lv_obj_create(lv_scr_act());
         lv_obj_set_size(apop, 480, 320);
         lv_obj_set_pos(apop, 0, 0);
-        lv_obj_set_style_bg_color(apop, lv_color_hex(0x000000), 0);
+        lv_obj_set_style_bg_color(apop, tc(TH_BLACK), 0);
         lv_obj_set_style_bg_opa(apop, LV_OPA_70, 0);
         lv_obj_set_style_border_width(apop, 0, 0);
         lv_obj_set_style_radius(apop, 0, 0);
@@ -321,7 +322,7 @@ void showConfirmPopup(const char* msg, int action) {
         lv_obj_t *atitle = lv_label_create(abox);
         char atbuf[48]; strncpy(atbuf, T(STR_AUTO_WEIGHT_TITLE), sizeof(atbuf)-1); atbuf[sizeof(atbuf)-1] = '\0';
         lv_label_set_text(atitle, atbuf);
-        lv_obj_set_style_text_color(atitle, lv_color_hex(0x28d49a), 0);
+        lv_obj_set_style_text_color(atitle, tc(TH_ACCENT), 0);
         lv_obj_set_style_text_font(atitle, &lv_font_montserrat_ext_16, 0);
         lv_obj_set_style_text_align(atitle, LV_TEXT_ALIGN_CENTER, 0);
         lv_obj_set_width(atitle, 444);
@@ -331,7 +332,7 @@ void showConfirmPopup(const char* msg, int action) {
         lv_obj_t *ainfo = lv_label_create(abox);
         char aibuf[160]; strncpy(aibuf, T(STR_AUTO_WEIGHT_INFO), sizeof(aibuf)-1); aibuf[sizeof(aibuf)-1] = '\0';
         lv_label_set_text(ainfo, aibuf);
-        lv_obj_set_style_text_color(ainfo, lv_color_hex(0xc8d8f0), 0);
+        lv_obj_set_style_text_color(ainfo, tc(TH_TEXT), 0);
         lv_obj_set_style_text_font(ainfo, &lv_font_montserrat_ext_14, 0);
         lv_obj_set_style_text_align(ainfo, LV_TEXT_ALIGN_CENTER, 0);
         lv_label_set_long_mode(ainfo, LV_LABEL_LONG_WRAP);
@@ -342,8 +343,8 @@ void showConfirmPopup(const char* msg, int action) {
         lv_obj_t *abtn_ok = lv_btn_create(abox);
         lv_obj_set_size(abtn_ok, 222, 52);
         lv_obj_set_pos(abtn_ok, 8, 156);
-        lv_obj_set_style_bg_color(abtn_ok, lv_color_hex(0x1a3020), 0);
-        lv_obj_set_style_bg_color(abtn_ok, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+        lv_obj_set_style_bg_color(abtn_ok, tc(TH_OK_BG), 0);
+        lv_obj_set_style_bg_color(abtn_ok, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
         lv_obj_set_style_radius(abtn_ok, 8, 0);
         lv_obj_set_style_shadow_width(abtn_ok, 0, 0);
         lv_obj_add_event_cb(abtn_ok, [](lv_event_t *e) {
@@ -358,7 +359,7 @@ void showConfirmPopup(const char* msg, int action) {
             char wmbuf[48];
             snprintf(wmbuf, sizeof(wmbuf), "%s (A)", T(STR_BTN_WEIGHT));
             lv_label_set_text(lbl_weight_main_lbl, wmbuf);
-            lv_obj_set_style_text_color(lbl_weight_main_lbl, lv_color_hex(0x28d49a), 0);
+            lv_obj_set_style_text_color(lbl_weight_main_lbl, tc(TH_ACCENT), 0);
           }
           lv_obj_del(apop);         // zweites Popup weg
           closeConfirmPopup();      // erstes Popup weg
@@ -366,7 +367,7 @@ void showConfirmPopup(const char* msg, int action) {
         lv_obj_t *abtn_ok_lbl = lv_label_create(abtn_ok);
         char acbuf[32]; strncpy(acbuf, T(STR_CONFIRM), sizeof(acbuf)-1); acbuf[sizeof(acbuf)-1] = '\0';
         lv_label_set_text(abtn_ok_lbl, acbuf);
-        lv_obj_set_style_text_color(abtn_ok_lbl, lv_color_hex(0x40c080), 0);
+        lv_obj_set_style_text_color(abtn_ok_lbl, tc(TH_SUCCESS_TEXT), 0);
         lv_obj_set_style_text_font(abtn_ok_lbl, &lv_font_montserrat_ext_14, 0);
         lv_obj_align(abtn_ok_lbl, LV_ALIGN_CENTER, 0, 0);
 
@@ -374,8 +375,8 @@ void showConfirmPopup(const char* msg, int action) {
         lv_obj_t *abtn_cancel = lv_btn_create(abox);
         lv_obj_set_size(abtn_cancel, 222, 52);
         lv_obj_set_pos(abtn_cancel, 238, 156);
-        lv_obj_set_style_bg_color(abtn_cancel, lv_color_hex(0x3a1010), 0);
-        lv_obj_set_style_bg_color(abtn_cancel, lv_color_hex(0x602020), LV_STATE_PRESSED);
+        lv_obj_set_style_bg_color(abtn_cancel, tc(TH_DANGER_BG), 0);
+        lv_obj_set_style_bg_color(abtn_cancel, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
         lv_obj_set_style_radius(abtn_cancel, 8, 0);
         lv_obj_set_style_shadow_width(abtn_cancel, 0, 0);
         lv_obj_add_event_cb(abtn_cancel, [](lv_event_t *e) {
@@ -387,7 +388,7 @@ void showConfirmPopup(const char* msg, int action) {
         lv_obj_t *abtn_cancel_lbl = lv_label_create(abtn_cancel);
         char acancelbuf[32]; strncpy(acancelbuf, T(STR_CANCEL), sizeof(acancelbuf)-1); acancelbuf[sizeof(acancelbuf)-1] = '\0';
         lv_label_set_text(abtn_cancel_lbl, acancelbuf);
-        lv_obj_set_style_text_color(abtn_cancel_lbl, lv_color_hex(0xff8080), 0);
+        lv_obj_set_style_text_color(abtn_cancel_lbl, tc(TH_DANGER_TEXT), 0);
         lv_obj_set_style_text_font(abtn_cancel_lbl, &lv_font_montserrat_ext_14, 0);
         lv_obj_align(abtn_cancel_lbl, LV_ALIGN_CENTER, 0, 0);
       }
@@ -399,7 +400,7 @@ void showConfirmPopup(const char* msg, int action) {
       abuf[sizeof(abuf)-1] = '\0';
       lv_label_set_text(lbl_auto_weight_btn, abuf);
     }
-    lv_obj_set_style_text_color(lbl_auto_weight_btn, g_auto_weight ? lv_color_hex(0x28d49a) : lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl_auto_weight_btn, g_auto_weight ? tc(TH_ACCENT) : tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl_auto_weight_btn, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(lbl_auto_weight_btn, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_center(lbl_auto_weight_btn);
@@ -429,14 +430,14 @@ void showConfirmPopup(const char* msg, int action) {
     lv_obj_t *btn7 = lv_btn_create(box);
     lv_obj_set_size(btn7, BW_FULL, H_ROW4);
     lv_obj_set_pos(btn7, XL, Y4);
-    lv_obj_set_style_bg_color(btn7, lv_color_hex(0x3a1010), 0);
-    lv_obj_set_style_bg_color(btn7, lv_color_hex(0x602020), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn7, tc(TH_DANGER_BG), 0);
+    lv_obj_set_style_bg_color(btn7, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn7, 8, 0);
     lv_obj_set_style_shadow_width(btn7, 0, 0);
     lv_obj_add_event_cb(btn7, [](lv_event_t *e){ closeConfirmPopup(); }, LV_EVENT_CLICKED, NULL);
     lv_obj_t *l7 = lv_label_create(btn7);
     lv_label_set_text(l7, T(STR_CANCEL));
-    lv_obj_set_style_text_color(l7, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(l7, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(l7, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(l7, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_center(l7);
@@ -471,15 +472,15 @@ void showConfirmPopup(const char* msg, int action) {
     lv_obj_t *btn_nein = lv_btn_create(box);
     lv_obj_set_size(btn_nein, 170, 56);
     lv_obj_set_pos(btn_nein, 218, 122);
-    lv_obj_set_style_bg_color(btn_nein, lv_color_hex(0x3a1010), 0);
-    lv_obj_set_style_bg_color(btn_nein, lv_color_hex(0x602020), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_nein, tc(TH_DANGER_BG), 0);
+    lv_obj_set_style_bg_color(btn_nein, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_nein, 8, 0);
     lv_obj_set_style_shadow_width(btn_nein, 0, 0);
     lv_obj_add_event_cb(btn_nein, [](lv_event_t *e){ closeConfirmPopup(); }, LV_EVENT_CLICKED, NULL);
     lv_obj_t *lbl_nein = lv_label_create(btn_nein);
     lv_label_set_text(lbl_nein, T(STR_CANCEL));
     lv_obj_set_style_text_font(lbl_nein, &lv_font_montserrat_ext_18, 0);
-    lv_obj_set_style_text_color(lbl_nein, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_nein, tc(TH_DANGER_TEXT), 0);
     lv_obj_center(lbl_nein);
   }
 }

--- a/src/ui/connection_screen.cpp
+++ b/src/ui/connection_screen.cpp
@@ -12,6 +12,7 @@
 #include "ui_common.h"
 #include "wifi_info.h"
 #include "services/wifi_manager.h"
+#include "theme.h"
 
 
 void showWifiSetupScreen();
@@ -67,26 +68,26 @@ void buildConnectionScreen() {
   lv_obj_t *btn_wifi = lv_btn_create(scr_connection);
   lv_obj_set_size(btn_wifi, BTN_W, BTN_H);
   lv_obj_set_pos(btn_wifi, BTN_X, BTN_Y[0]);
-  lv_obj_set_style_bg_color(btn_wifi, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn_wifi, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_wifi, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn_wifi, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_wifi, 10, 0);
   lv_obj_set_style_shadow_width(btn_wifi, 0, 0);
   lv_obj_set_style_border_width(btn_wifi, 1, 0);
-  lv_obj_set_style_border_color(btn_wifi, lv_color_hex(0x1a3050), 0);
+  lv_obj_set_style_border_color(btn_wifi, tc(TH_BORDER), 0);
   { lv_obj_t *ico = lv_label_create(btn_wifi);
     lv_label_set_text(ico, LV_SYMBOL_WIFI);
-    lv_obj_set_style_text_color(ico, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(ico, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(ico, &lv_font_montserrat_ext_24, 0);
     lv_obj_align(ico, LV_ALIGN_CENTER, 0, -24);
     lv_obj_t *lbl = lv_label_create(btn_wifi);
     lv_label_set_text(lbl, T(STR_BTN_WIFI_SETTINGS));
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_18, 0);
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl, LV_ALIGN_CENTER, 0, 4);
     lv_obj_t *sub = lv_label_create(btn_wifi);
     lv_label_set_text(sub, cfg_wifi_ssid[0] ? cfg_wifi_ssid : T(STR_BTN_WIFI_NONE));
-    lv_obj_set_style_text_color(sub, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(sub, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(sub, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(sub, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(sub, LV_ALIGN_CENTER, 0, 26); }
@@ -95,27 +96,27 @@ void buildConnectionScreen() {
   lv_obj_t *btn_ws = lv_btn_create(scr_connection);
   lv_obj_set_size(btn_ws, BTN_W, BTN_H);
   lv_obj_set_pos(btn_ws, BTN_X, BTN_Y[1]);
-  lv_obj_set_style_bg_color(btn_ws, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn_ws, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_ws, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn_ws, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_ws, 10, 0);
   lv_obj_set_style_shadow_width(btn_ws, 0, 0);
   lv_obj_set_style_border_width(btn_ws, 1, 0);
-  lv_obj_set_style_border_color(btn_ws, lv_color_hex(0x1a3050), 0);
+  lv_obj_set_style_border_color(btn_ws, tc(TH_BORDER), 0);
   { lv_obj_t *ico = lv_label_create(btn_ws);
     lv_label_set_text(ico, LV_SYMBOL_GPS);
-    lv_obj_set_style_text_color(ico, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(ico, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(ico, &lv_font_montserrat_ext_24, 0);
     lv_obj_align(ico, LV_ALIGN_CENTER, 0, -24);
     lv_obj_t *lbl = lv_label_create(btn_ws);
     lv_label_set_text(lbl, T(STR_BTN_WIFI_STATUS));
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_18, 0);
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl, LV_ALIGN_CENTER, 0, 4);
     lv_obj_t *sub = lv_label_create(btn_ws);
     lbl_wifi_ip = sub;
     { char ipbuf[24]; wifiIpText(ipbuf, sizeof(ipbuf)); lv_label_set_text(sub, ipbuf); }
-    lv_obj_set_style_text_color(sub, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(sub, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(sub, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(sub, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(sub, LV_ALIGN_CENTER, 0, 26); }
@@ -131,15 +132,15 @@ void buildConnectionScreen() {
   lv_obj_t *btn_sp = lv_btn_create(scr_connection);
   lv_obj_set_size(btn_sp, BTN_W, BTN_H);
   lv_obj_set_pos(btn_sp, BTN_X, BTN_Y[2]);
-  lv_obj_set_style_bg_color(btn_sp, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn_sp, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_sp, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn_sp, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_sp, 10, 0);
   lv_obj_set_style_shadow_width(btn_sp, 0, 0);
   lv_obj_set_style_border_width(btn_sp, 1, 0);
-  lv_obj_set_style_border_color(btn_sp, lv_color_hex(0x1a3050), 0);
+  lv_obj_set_style_border_color(btn_sp, tc(TH_BORDER), 0);
   { lv_obj_t *ico = lv_label_create(btn_sp);
     lv_label_set_text(ico, LV_SYMBOL_SETTINGS);
-    lv_obj_set_style_text_color(ico, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(ico, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(ico, &lv_font_montserrat_ext_24, 0);
     lv_obj_align(ico, LV_ALIGN_CENTER, 0, -24);
     char buf_backend[32];
@@ -147,7 +148,7 @@ void buildConnectionScreen() {
     buf_backend[sizeof(buf_backend)-1] = '\0';
     lv_obj_t *lbl = lv_label_create(btn_sp);
     lv_label_set_text(lbl, buf_backend);
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_18, 0);
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl, LV_ALIGN_CENTER, 0, 4);
@@ -160,7 +161,7 @@ void buildConnectionScreen() {
       (host && host[0]) ? host : T(STR_BTN_WIFI_NONE));
     lv_obj_t *sub = lv_label_create(btn_sp);
     lv_label_set_text(sub, buf_sub);
-    lv_obj_set_style_text_color(sub, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(sub, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(sub, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(sub, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(sub, LV_ALIGN_CENTER, 0, 26); }

--- a/src/ui/date_display.cpp
+++ b/src/ui/date_display.cpp
@@ -8,6 +8,7 @@
 #include "hardware/sd_logger.h"
 #include "lang.h"
 #include "services/drying_config.h"
+#include "theme.h"
 
 static int dryingAlertLevel(const char* last_dried_local);
 
@@ -107,8 +108,8 @@ void applyDriedLabel(lv_obj_t* lbl_val, lv_obj_t* lbl_sym, const char* de_date) 
   if (sd_verbose) logSDf("[verbose] applyDriedLabel: date=%s level=%d mode=%d", de_date, level, g_dry_mode);
   uint32_t col;
   if      (level == 2) col = 0xe04040;  // rot
-  else if (level == 1) col = 0xf0b838;  // gelb
-  else if (level == 0) col = 0x28d49a;  // gruen
+  else if (level == 1) col = g_theme[TH_WARNING];  // gelb
+  else if (level == 0) col = g_theme[TH_ACCENT];  // gruen
   else                 col = 0x5090e0;  // kein Modus / kein Datum -> neutral blau
   lv_obj_set_style_text_color(lbl_val, lv_color_hex(col), 0);
   // Symbol (nur bei Warnung/Alarm)

--- a/src/ui/display_screen.cpp
+++ b/src/ui/display_screen.cpp
@@ -11,6 +11,7 @@
 #include "lang.h"
 #include "services/prefs_store.h"
 #include "ui_common.h"
+#include "theme.h"
 
 
 
@@ -33,7 +34,7 @@ void buildDisplayScreen() {
 
   lv_obj_t *lbl_bright = lv_label_create(scr_display);
   lv_label_set_text(lbl_bright, T(STR_BRIGHT_LABEL));
-  lv_obj_set_style_text_color(lbl_bright, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_bright, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_bright, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_bright, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_bright, LV_ALIGN_TOP_MID, 0, 54);
@@ -43,9 +44,9 @@ void buildDisplayScreen() {
   lv_obj_set_pos(slider, 12, 76);
   lv_slider_set_range(slider, BRIGHT_MIN, BRIGHT_MAX);
   lv_slider_set_value(slider, bright_normal, LV_ANIM_OFF);
-  lv_obj_set_style_bg_color(slider, lv_color_hex(0x1a3060), LV_PART_MAIN);
-  lv_obj_set_style_bg_color(slider, lv_color_hex(0x28d49a), LV_PART_INDICATOR);
-  lv_obj_set_style_bg_color(slider, lv_color_hex(0x28d49a), LV_PART_KNOB);
+  lv_obj_set_style_bg_color(slider, tc(TH_SURFACE_2), LV_PART_MAIN);
+  lv_obj_set_style_bg_color(slider, tc(TH_ACCENT), LV_PART_INDICATOR);
+  lv_obj_set_style_bg_color(slider, tc(TH_ACCENT), LV_PART_KNOB);
 
   lv_obj_add_event_cb(slider, [](lv_event_t *e) {
     lv_obj_t *s = lv_event_get_target(e);
@@ -61,7 +62,7 @@ void buildDisplayScreen() {
 
   lv_obj_t *lbl_dim = lv_label_create(scr_display);
   lv_label_set_text(lbl_dim, T(STR_DIM_LABEL));
-  lv_obj_set_style_text_color(lbl_dim, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_dim, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_dim, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_dim, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_dim, LV_ALIGN_TOP_MID, 0, 108);
@@ -75,14 +76,14 @@ void buildDisplayScreen() {
     lv_obj_set_size(b, BTN_W, BTN_H);
     lv_obj_set_pos(b, BTN_START_X + i * (BTN_W + BTN_GAP), 130);
     bool active = (cur_dim == dim_vals[i]);
-    lv_obj_set_style_bg_color(b, active ? lv_color_hex(0x28d49a) : lv_color_hex(0x1a3060), 0);
+    lv_obj_set_style_bg_color(b, active ? tc(TH_ACCENT) : tc(TH_SURFACE_2), 0);
     lv_obj_set_style_radius(b, 8, 0);
     lv_obj_set_style_shadow_width(b, 0, 0);
     lv_obj_set_style_border_width(b, 0, 0);
     char buf[8]; snprintf(buf, sizeof(buf), "%d Min", dim_vals[i]);
     lv_obj_t *l = lv_label_create(b);
     lv_label_set_text(l, buf);
-    lv_obj_set_style_text_color(l, active ? lv_color_hex(0x0a1020) : lv_color_hex(0xc8d8f0), 0);
+    lv_obj_set_style_text_color(l, active ? tc(TH_BG) : tc(TH_TEXT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_14, 0);
     lv_obj_center(l);
     lv_obj_add_event_cb(b, [](lv_event_t *e) {
@@ -96,7 +97,7 @@ void buildDisplayScreen() {
 
   lv_obj_t *lbl_sleep = lv_label_create(scr_display);
   lv_label_set_text(lbl_sleep, T(STR_SLEEP_LABEL));
-  lv_obj_set_style_text_color(lbl_sleep, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_sleep, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_sleep, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_sleep, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_sleep, LV_ALIGN_TOP_MID, 0, 178);
@@ -113,7 +114,7 @@ void buildDisplayScreen() {
     lv_obj_set_size(b, BTN_W, BTN_H);
     lv_obj_set_pos(b, SLEEP_START_X + i * (BTN_W + SLEEP_BTN_GAP), 200);
     bool active = (cur_sleep == sleep_vals[i]);
-    lv_obj_set_style_bg_color(b, active ? lv_color_hex(0x28d49a) : lv_color_hex(0x1a3060), 0);
+    lv_obj_set_style_bg_color(b, active ? tc(TH_ACCENT) : tc(TH_SURFACE_2), 0);
     lv_obj_set_style_radius(b, 8, 0);
     lv_obj_set_style_shadow_width(b, 0, 0);
     lv_obj_set_style_border_width(b, 0, 0);
@@ -126,7 +127,7 @@ void buildDisplayScreen() {
     }
     lv_obj_t *l = lv_label_create(b);
     lv_label_set_text(l, buf);
-    lv_obj_set_style_text_color(l, active ? lv_color_hex(0x0a1020) : lv_color_hex(0xc8d8f0), 0);
+    lv_obj_set_style_text_color(l, active ? tc(TH_BG) : tc(TH_TEXT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_14, 0);
     lv_obj_center(l);
     lv_obj_add_event_cb(b, [](lv_event_t *e) {
@@ -140,7 +141,7 @@ void buildDisplayScreen() {
 
   lv_obj_t *hint = lv_label_create(scr_display);
   lv_label_set_text(hint, T(STR_DISPLAY_HINT));
-  lv_obj_set_style_text_color(hint, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(hint, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(hint, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(hint, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(hint, LV_LABEL_LONG_WRAP);

--- a/src/ui/drying_reminder_screen.cpp
+++ b/src/ui/drying_reminder_screen.cpp
@@ -13,6 +13,7 @@
 #include "services/drying_config.h"
 #include "services/prefs_store.h"
 #include "ui_common.h"
+#include "theme.h"
 
 
 // ============================================================
@@ -43,13 +44,13 @@ static void buildDryNumpadScreen(int target) {
   lv_obj_set_size(val_box, 380, 44);
   lv_obj_set_pos(val_box, 50, 68);
   lv_obj_set_style_bg_color(val_box, lv_color_hex(0x050f1e), 0);
-  lv_obj_set_style_border_color(val_box, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_border_color(val_box, tc(TH_ACCENT), 0);
   lv_obj_set_style_border_width(val_box, 1, 0);
   lv_obj_set_style_radius(val_box, 8, 0);
   s_dry_numpad_lbl = lv_label_create(val_box);
   char vbuf[16]; snprintf(vbuf, sizeof(vbuf), "%d %s", s_dry_numpad_value, T(STR_DRY_DAYS_UNIT));
   lv_label_set_text(s_dry_numpad_lbl, vbuf);
-  lv_obj_set_style_text_color(s_dry_numpad_lbl, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(s_dry_numpad_lbl, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(s_dry_numpad_lbl, &lv_font_montserrat_ext_24, 0);
   lv_obj_align(s_dry_numpad_lbl, LV_ALIGN_CENTER, 0, 0);
 
@@ -71,17 +72,17 @@ static void buildDryNumpadScreen(int target) {
     lv_obj_set_pos(kb, bx, by);
     lv_obj_set_style_bg_color(kb, is_del ? lv_color_hex(0x1a1020) :
                                   is_ok  ? lv_color_hex(0x1a4030) :
-                                           lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_bg_color(kb, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+                                           tc(TH_SURFACE), 0);
+    lv_obj_set_style_bg_color(kb, tc(TH_BORDER), LV_STATE_PRESSED);
     lv_obj_set_style_radius(kb, 6, 0);
     lv_obj_set_style_shadow_width(kb, 0, 0);
     lv_obj_set_style_border_width(kb, 1, 0);
-    lv_obj_set_style_border_color(kb, is_ok ? lv_color_hex(0x28d49a) : lv_color_hex(0x1a3050), 0);
+    lv_obj_set_style_border_color(kb, is_ok ? tc(TH_ACCENT) : tc(TH_BORDER), 0);
     lv_obj_t *kl = lv_label_create(kb);
     lv_label_set_text(kl, is_ok ? LV_SYMBOL_OK : keys[i]);
     lv_obj_set_style_text_color(kl, is_del ? lv_color_hex(0xe04040) :
-                                     is_ok  ? lv_color_hex(0x28d49a) :
-                                              lv_color_hex(0xe8f0ff), 0);
+                                     is_ok  ? tc(TH_ACCENT) :
+                                              tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(kl, &lv_font_montserrat_ext_18, 0);
     lv_obj_align(kl, LV_ALIGN_CENTER, 0, 0);
     lv_obj_set_user_data(kb, (void*)keys[i]);
@@ -141,15 +142,15 @@ void showDryingReminderScreen() {
     lv_obj_t *mb = lv_btn_create(scr_drying_reminder);
     lv_obj_set_size(mb, btn_w, btn_h);
     lv_obj_set_pos(mb, btn_x0 + m*(btn_w+btn_gap), btn_y);
-    lv_obj_set_style_bg_color(mb, active ? lv_color_hex(0x0d2e1a) : lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_bg_color(mb, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
-    lv_obj_set_style_border_color(mb, active ? lv_color_hex(0x28d49a) : lv_color_hex(0x1a3050), 0);
+    lv_obj_set_style_bg_color(mb, active ? lv_color_hex(0x0d2e1a) : tc(TH_SURFACE), 0);
+    lv_obj_set_style_bg_color(mb, tc(TH_BORDER), LV_STATE_PRESSED);
+    lv_obj_set_style_border_color(mb, active ? tc(TH_ACCENT) : tc(TH_BORDER), 0);
     lv_obj_set_style_border_width(mb, 1, 0);
     lv_obj_set_style_radius(mb, 8, 0);
     lv_obj_set_style_shadow_width(mb, 0, 0);
     lv_obj_t *ml = lv_label_create(mb);
     lv_label_set_text(ml, mode_labels[m]);
-    lv_obj_set_style_text_color(ml, active ? lv_color_hex(0x28d49a) : lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(ml, active ? tc(TH_ACCENT) : tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(ml, &lv_font_montserrat_ext_16, 0);
     lv_obj_align(ml, LV_ALIGN_CENTER, 0, 0);
     lv_obj_set_user_data(mb, (void*)(intptr_t)m);
@@ -171,7 +172,7 @@ void showDryingReminderScreen() {
     lv_obj_t *lbl = lv_label_create(scr_drying_reminder);
     { char dbuf[200]; strncpy(dbuf, T(STR_DRY_OFF_DESC), sizeof(dbuf)-1);
       lv_label_set_text(lbl, dbuf); }
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_set_width(lbl, 440);
@@ -183,7 +184,7 @@ void showDryingReminderScreen() {
     lv_obj_t *hint = lv_label_create(scr_drying_reminder);
     { char hbuf[64]; strncpy(hbuf, T(STR_DRY_MAT_HINT), sizeof(hbuf)-1); hbuf[sizeof(hbuf)-1]=0;
       lv_label_set_text(hint, hbuf); }
-    lv_obj_set_style_text_color(hint, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(hint, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(hint, &lv_font_montserrat_ext_12, 0);
     lv_obj_set_style_text_align(hint, LV_TEXT_ALIGN_LEFT, 0);
     lv_obj_set_width(hint, 300);
@@ -195,12 +196,12 @@ void showDryingReminderScreen() {
     lv_obj_t *btn_web = lv_btn_create(scr_drying_reminder);
     lv_obj_set_size(btn_web, 150, 26);
     lv_obj_set_pos(btn_web, 318, content_y - 6);
-    lv_obj_set_style_bg_color(btn_web, lv_color_hex(0x0a1e30), 0);
-    lv_obj_set_style_bg_color(btn_web, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_web, tc(TH_TILE_BG), 0);
+    lv_obj_set_style_bg_color(btn_web, tc(TH_BORDER), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_web, 6, 0);
     lv_obj_set_style_shadow_width(btn_web, 0, 0);
     lv_obj_set_style_border_width(btn_web, 1, 0);
-    lv_obj_set_style_border_color(btn_web, lv_color_hex(0x1a3060), 0);
+    lv_obj_set_style_border_color(btn_web, tc(TH_SURFACE_2), 0);
     lv_obj_add_event_cb(btn_web, [](lv_event_t *e) {
       logSD("BTN: Drying -> Web interface");
       showOtaBrowserScreen(WEB_CTX_DRYING);
@@ -208,7 +209,7 @@ void showDryingReminderScreen() {
     lv_obj_t *lbl_web = lv_label_create(btn_web);
     { char wbuf[32]; snprintf(wbuf, sizeof(wbuf), "%s  " LV_SYMBOL_RIGHT, T(STR_BTN_OPEN_BROWSER));
       lv_label_set_text(lbl_web, wbuf); }
-    lv_obj_set_style_text_color(lbl_web, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(lbl_web, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(lbl_web, &lv_font_montserrat_ext_12, 0);
     lv_obj_center(lbl_web);
 
@@ -219,7 +220,7 @@ void showDryingReminderScreen() {
     lv_obj_set_size(tbl_cont, 456, 162);
     lv_obj_set_pos(tbl_cont, 12, content_y + 4);
     lv_obj_set_style_bg_color(tbl_cont, lv_color_hex(0x050f1e), 0);
-    lv_obj_set_style_border_color(tbl_cont, lv_color_hex(0x1a3050), 0);
+    lv_obj_set_style_border_color(tbl_cont, tc(TH_BORDER), 0);
     lv_obj_set_style_border_width(tbl_cont, 1, 0);
     lv_obj_set_style_radius(tbl_cont, 8, 0);
     lv_obj_set_style_pad_all(tbl_cont, 6, 0);
@@ -236,7 +237,7 @@ void showDryingReminderScreen() {
       auto hdr = [&](const char* t, int x, int w){
         lv_obj_t *l = lv_label_create(row);
         lv_label_set_text(l, t);
-        lv_obj_set_style_text_color(l, lv_color_hex(0x4a6fa0), 0);
+        lv_obj_set_style_text_color(l, tc(TH_TEXT_MUTED), 0);
         lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_12, 0);
         lv_obj_set_width(l, w);
         lv_obj_set_pos(l, x, 4);
@@ -248,7 +249,7 @@ void showDryingReminderScreen() {
       hdr(h0,0,72); hdr(h1,80,120); hdr(h2,210,120);
       lv_obj_t *h4l = lv_label_create(row);
       lv_label_set_text(h4l, T(STR_DRY_SEALED_HDR));
-      lv_obj_set_style_text_color(h4l, lv_color_hex(0x4a6fa0), 0);
+      lv_obj_set_style_text_color(h4l, tc(TH_TEXT_MUTED), 0);
       lv_obj_set_style_text_font(h4l, &lv_font_montserrat_ext_12, 0);
       lv_obj_set_width(h4l, 50); lv_obj_set_pos(h4l, 366, 4); }
     }
@@ -274,20 +275,20 @@ void showDryingReminderScreen() {
       char y_buf[10], r_buf[10];
       snprintf(y_buf, sizeof(y_buf), "%d T.", eff_y);
       snprintf(r_buf, sizeof(r_buf), "%d T.", eff_r);
-      cell(DRY_MAT_NAMES[i], 0,  72, 0xe8f0ff);
-      cell(y_buf,            80, 120, 0xf0b838);
+      cell(DRY_MAT_NAMES[i], 0,  72, g_theme[TH_TEXT_BRIGHT]);
+      cell(y_buf,            80, 120, g_theme[TH_WARNING]);
       cell(r_buf,           210, 120, 0xe04040);
       // Sealed-Symbol
       lv_obj_t *seal_lbl = lv_label_create(row);
       lv_label_set_text(seal_lbl, g_dry_mat_sealed[i] ? LV_SYMBOL_OK : "-");
-      lv_obj_set_style_text_color(seal_lbl, g_dry_mat_sealed[i] ? lv_color_hex(0x28d49a) : lv_color_hex(0x2a4060), 0);
+      lv_obj_set_style_text_color(seal_lbl, g_dry_mat_sealed[i] ? tc(TH_ACCENT) : tc(TH_TEXT_DIM), 0);
       lv_obj_set_style_text_font(seal_lbl, &lv_font_montserrat_ext_14, 0);
       lv_obj_set_pos(seal_lbl, 370, 2);
     }
     // Fussnote
     lv_obj_t *fn = lv_label_create(scr_drying_reminder);
     { char fnbuf[80]; snprintf(fnbuf, sizeof(fnbuf), T(STR_DRY_MAT_EFF_NOTE), g_dry_mult_sealed); lv_label_set_text(fn, fnbuf); }
-    lv_obj_set_style_text_color(fn, lv_color_hex(0x2a4060), 0);
+    lv_obj_set_style_text_color(fn, tc(TH_TEXT_DIM), 0);
     lv_obj_set_style_text_font(fn, &lv_font_montserrat_ext_12, 0);
     lv_obj_align(fn, LV_ALIGN_BOTTOM_MID, 0, -4);
 
@@ -297,8 +298,8 @@ void showDryingReminderScreen() {
       lv_obj_t *row_btn = lv_btn_create(scr_drying_reminder);
       lv_obj_set_size(row_btn, 456, 56);
       lv_obj_set_pos(row_btn, 12, y);
-      lv_obj_set_style_bg_color(row_btn, lv_color_hex(0x0a1e30), 0);
-      lv_obj_set_style_bg_color(row_btn, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+      lv_obj_set_style_bg_color(row_btn, tc(TH_TILE_BG), 0);
+      lv_obj_set_style_bg_color(row_btn, tc(TH_BORDER), LV_STATE_PRESSED);
       lv_obj_set_style_radius(row_btn, 10, 0);
       lv_obj_set_style_shadow_width(row_btn, 0, 0);
       lv_obj_set_style_border_width(row_btn, 1, 0);
@@ -314,13 +315,13 @@ void showDryingReminderScreen() {
       // Label
       lv_obj_t *lbl = lv_label_create(row_btn);
       lv_label_set_text(lbl, label);
-      lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+      lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
       lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_16, 0);
       lv_obj_align(lbl, LV_ALIGN_LEFT_MID, 24, -8);
       // Untertitel
       lv_obj_t *slbl = lv_label_create(row_btn);
       { char ehbuf[32]; strncpy(ehbuf, T(STR_DRY_MAN_EDIT_HINT), sizeof(ehbuf)-1); lv_label_set_text(slbl, ehbuf); }
-      lv_obj_set_style_text_color(slbl, lv_color_hex(0x2a4060), 0);
+      lv_obj_set_style_text_color(slbl, tc(TH_TEXT_DIM), 0);
       lv_obj_set_style_text_font(slbl, &lv_font_montserrat_ext_12, 0);
       lv_obj_align(slbl, LV_ALIGN_LEFT_MID, 24, 10);
       // Wert rechts
@@ -338,13 +339,13 @@ void showDryingReminderScreen() {
         lv_obj_clear_flag(s_dry_numpad_scr, LV_OBJ_FLAG_HIDDEN);
       }, LV_EVENT_CLICKED, NULL);
     };
-    { char ybuf[16]; strncpy(ybuf, T(STR_DRY_MAN_YELLOW_LBL), sizeof(ybuf)-1); makeThreshRow(ybuf, g_dry_man_yellow, 0xf0b838, content_y,      0); }
+    { char ybuf[16]; strncpy(ybuf, T(STR_DRY_MAN_YELLOW_LBL), sizeof(ybuf)-1); makeThreshRow(ybuf, g_dry_man_yellow, g_theme[TH_WARNING], content_y,      0); }
     { char rbuf[16]; strncpy(rbuf, T(STR_DRY_MAN_RED_LBL),    sizeof(rbuf)-1); makeThreshRow(rbuf, g_dry_man_red,    0xe04040, content_y + 68, 1); }
 
     // Info-Text
     lv_obj_t *info = lv_label_create(scr_drying_reminder);
     { char ibuf[64]; strncpy(ibuf, T(STR_DRY_MAN_INFO), sizeof(ibuf)-1); lv_label_set_text(info, ibuf); }
-    lv_obj_set_style_text_color(info, lv_color_hex(0x2a4060), 0);
+    lv_obj_set_style_text_color(info, tc(TH_TEXT_DIM), 0);
     lv_obj_set_style_text_font(info, &lv_font_montserrat_ext_12, 0);
     lv_obj_set_style_text_align(info, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_set_width(info, 440);

--- a/src/ui/extra_fields_screen.cpp
+++ b/src/ui/extra_fields_screen.cpp
@@ -13,6 +13,7 @@
 #include "lang.h"
 #include "ui_common.h"
 #include "services/backend.h"
+#include "theme.h"
 
 
 
@@ -76,7 +77,7 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
   lv_obj_set_style_border_width(scr_extra_fields, 0, 0);
   lv_obj_set_style_pad_all(scr_extra_fields, 0, 0);
   lv_obj_clear_flag(scr_extra_fields, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr_extra_fields, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_extra_fields, tc(TH_BG), 0);
 
   // Header: back returns to the filament manager screen, which is where this
   // screen is now reached from. Setup flow gets a title and an X instead.
@@ -92,7 +93,7 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
     // Setup flow: title only + X (→ main screen), no back button
     lv_obj_t *lbl_title = lv_label_create(scr_extra_fields);
     { char tb[40]; backendText(T(STR_EXTRA_FIELDS_TITLE), tb, sizeof(tb)); lv_label_set_text(lbl_title, tb); }
-    lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
     lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 12);
 
@@ -100,15 +101,15 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
     lv_obj_t *btn_x = lv_btn_create(scr_extra_fields);
     lv_obj_set_size(btn_x, 44, 44);
     lv_obj_align(btn_x, LV_ALIGN_TOP_RIGHT, -4, 2);
-    lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x3a1010), 0);
-    lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x602020), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_BG), 0);
+    lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_x, 8, 0);
     lv_obj_set_style_shadow_width(btn_x, 0, 0);
     lv_obj_set_style_border_width(btn_x, 0, 0);
     lv_obj_add_event_cb(btn_x, [](lv_event_t *e){ logSD("BTN: Close -> Main"); showMainScreen(); }, LV_EVENT_CLICKED, NULL);
     lv_obj_t *lbl_x = lv_label_create(btn_x);
     lv_label_set_text(lbl_x, LV_SYMBOL_CLOSE);
-    lv_obj_set_style_text_color(lbl_x, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_x, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(lbl_x, &lv_font_montserrat_ext_18, 0);
     lv_obj_center(lbl_x);
   }
@@ -116,7 +117,7 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
   // Hint text
   lv_obj_t *lbl_hint = lv_label_create(scr_extra_fields);
   lv_label_set_text(lbl_hint, T(STR_EXTRA_FIELDS_HINT));
-  lv_obj_set_style_text_color(lbl_hint, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_hint, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_hint, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(lbl_hint, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_hint, LV_LABEL_LONG_WRAP);
@@ -127,25 +128,25 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
   lv_obj_t *btn_check = lv_btn_create(scr_extra_fields);
   lv_obj_set_size(btn_check, 280, 44);
   lv_obj_align(btn_check, LV_ALIGN_TOP_MID, 0, 138);
-  lv_obj_set_style_bg_color(btn_check, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn_check, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_check, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn_check, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_check, 8, 0);
   lv_obj_set_style_shadow_width(btn_check, 0, 0);
   lv_obj_set_style_border_width(btn_check, 1, 0);
-  lv_obj_set_style_border_color(btn_check, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_check, tc(TH_SURFACE_2), 0);
   lv_obj_add_event_cb(btn_check, [](lv_event_t *e) {
     extra_fields_check_pending = true;
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_check = lv_label_create(btn_check);
   lv_label_set_text(lbl_check, T(STR_EXTRA_FIELDS_CHECK_BTN));
-  lv_obj_set_style_text_color(lbl_check, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_check, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_check, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_check);
 
   // Status label — below check button
   lbl_extra_fields_status = lv_label_create(scr_extra_fields);
   lv_label_set_text(lbl_extra_fields_status, "");
-  lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_extra_fields_status, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_extra_fields_status, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_extra_fields_status, LV_LABEL_LONG_WRAP);
@@ -156,12 +157,12 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
   btn_extra_fields_create = lv_btn_create(scr_extra_fields);
   lv_obj_set_size(btn_extra_fields_create, 440, 42);
   lv_obj_align(btn_extra_fields_create, LV_ALIGN_TOP_MID, 0, 228);
-  lv_obj_set_style_bg_color(btn_extra_fields_create, lv_color_hex(0x1a3020), 0);
-  lv_obj_set_style_bg_color(btn_extra_fields_create, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_extra_fields_create, tc(TH_OK_BG), 0);
+  lv_obj_set_style_bg_color(btn_extra_fields_create, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_extra_fields_create, 8, 0);
   lv_obj_set_style_shadow_width(btn_extra_fields_create, 0, 0);
   lv_obj_set_style_border_width(btn_extra_fields_create, 1, 0);
-  lv_obj_set_style_border_color(btn_extra_fields_create, lv_color_hex(0x2a5030), 0);
+  lv_obj_set_style_border_color(btn_extra_fields_create, tc(TH_SUCCESS_BG), 0);
   lv_obj_add_flag(btn_extra_fields_create, LV_OBJ_FLAG_HIDDEN);
   lv_obj_add_event_cb(btn_extra_fields_create, [](lv_event_t *e) {
     // Confirmation popup
@@ -179,7 +180,7 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
     lv_obj_set_size(box, 420, 220);
     lv_obj_align(box, LV_ALIGN_CENTER, 0, 0);
     lv_obj_set_style_bg_color(box, lv_color_hex(0x0d1a2a), 0);
-    lv_obj_set_style_border_color(box, lv_color_hex(0x1a3060), 0);
+    lv_obj_set_style_border_color(box, tc(TH_SURFACE_2), 0);
     lv_obj_set_style_border_width(box, 1, 0);
     lv_obj_set_style_radius(box, 10, 0);
     lv_obj_set_style_pad_all(box, 0, 0);
@@ -187,13 +188,13 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
 
     lv_obj_t *lbl_ct = lv_label_create(box);
     lv_label_set_text(lbl_ct, T(STR_EXTRA_FIELDS_CONFIRM_TITLE));
-    lv_obj_set_style_text_color(lbl_ct, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(lbl_ct, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(lbl_ct, &lv_font_montserrat_ext_18, 0);
     lv_obj_align(lbl_ct, LV_ALIGN_TOP_MID, 0, 18);
 
     lv_obj_t *lbl_cm = lv_label_create(box);
     lv_label_set_text(lbl_cm, T(STR_EXTRA_FIELDS_CONFIRM_MSG));
-    lv_obj_set_style_text_color(lbl_cm, lv_color_hex(0xc8d8f0), 0);
+    lv_obj_set_style_text_color(lbl_cm, tc(TH_TEXT), 0);
     lv_obj_set_style_text_font(lbl_cm, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(lbl_cm, LV_TEXT_ALIGN_CENTER, 0);
     lv_label_set_long_mode(lbl_cm, LV_LABEL_LONG_WRAP);
@@ -204,8 +205,8 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
     lv_obj_t *btn_conf = lv_btn_create(box);
     lv_obj_set_size(btn_conf, 180, 44);
     lv_obj_align(btn_conf, LV_ALIGN_BOTTOM_RIGHT, -12, -12);
-    lv_obj_set_style_bg_color(btn_conf, lv_color_hex(0x1a3020), 0);
-    lv_obj_set_style_bg_color(btn_conf, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_conf, tc(TH_OK_BG), 0);
+    lv_obj_set_style_bg_color(btn_conf, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_conf, 8, 0);
     lv_obj_set_style_shadow_width(btn_conf, 0, 0);
     lv_obj_set_style_border_width(btn_conf, 0, 0);
@@ -219,7 +220,7 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
     }, LV_EVENT_CLICKED, NULL);
     lv_obj_t *lbl_conf = lv_label_create(btn_conf);
     lv_label_set_text(lbl_conf, T(STR_CONFIRM));
-    lv_obj_set_style_text_color(lbl_conf, lv_color_hex(0x40c080), 0);
+    lv_obj_set_style_text_color(lbl_conf, tc(TH_SUCCESS_TEXT), 0);
     lv_obj_set_style_text_font(lbl_conf, &lv_font_montserrat_ext_16, 0);
     lv_obj_center(lbl_conf);
 
@@ -227,7 +228,7 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
     lv_obj_t *btn_can = lv_btn_create(box);
     lv_obj_set_size(btn_can, 140, 44);
     lv_obj_align(btn_can, LV_ALIGN_BOTTOM_LEFT, 12, -12);
-    lv_obj_set_style_bg_color(btn_can, lv_color_hex(0x1a2030), 0);
+    lv_obj_set_style_bg_color(btn_can, tc(TH_SURFACE_DARK), 0);
     lv_obj_set_style_bg_color(btn_can, lv_color_hex(0x2a3040), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_can, 8, 0);
     lv_obj_set_style_shadow_width(btn_can, 0, 0);
@@ -239,14 +240,14 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
     }, LV_EVENT_CLICKED, NULL);
     lv_obj_t *lbl_can = lv_label_create(btn_can);
     lv_label_set_text(lbl_can, T(STR_CANCEL));
-    lv_obj_set_style_text_color(lbl_can, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl_can, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl_can, &lv_font_montserrat_ext_16, 0);
     lv_obj_center(lbl_can);
   }, LV_EVENT_CLICKED, NULL);
 
   lv_obj_t *lbl_create = lv_label_create(btn_extra_fields_create);
   lv_label_set_text(lbl_create, T(STR_EXTRA_FIELDS_CREATE_BTN));
-  lv_obj_set_style_text_color(lbl_create, lv_color_hex(0x40c080), 0);
+  lv_obj_set_style_text_color(lbl_create, tc(TH_SUCCESS_TEXT), 0);
   lv_obj_set_style_text_font(lbl_create, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_create);
 
@@ -259,12 +260,12 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
   lv_obj_t *btn_skip_bottom = btn_extra_fields_next;
   lv_obj_set_size(btn_skip_bottom, 210, 40);
   lv_obj_set_pos(btn_skip_bottom, 246, 276);
-  lv_obj_set_style_bg_color(btn_skip_bottom, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_skip_bottom, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_skip_bottom, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_skip_bottom, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_skip_bottom, 8, 0);
   lv_obj_set_style_shadow_width(btn_skip_bottom, 0, 0);
   lv_obj_set_style_border_width(btn_skip_bottom, 1, 0);
-  lv_obj_set_style_border_color(btn_skip_bottom, lv_color_hex(0x1a2840), 0);
+  lv_obj_set_style_border_color(btn_skip_bottom, tc(TH_SURFACE_3), 0);
   lv_obj_add_event_cb(btn_skip_bottom, [](lv_event_t *e) {
     // Only reachable in the setup chain now, so there is one way onwards.
     // Deferred: never call showCalReminderScreen from an LVGL callback.
@@ -274,7 +275,7 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
   char skip_buf[32];
   snprintf(skip_buf, sizeof(skip_buf), "%s  " LV_SYMBOL_RIGHT, T(STR_EXTRA_FIELDS_SKIP));
   lv_label_set_text(lbl_skip_b, skip_buf);
-  lv_obj_set_style_text_color(lbl_skip_b, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_skip_b, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_skip_b, &lv_font_montserrat_ext_14, 0);
   lv_obj_center(lbl_skip_b);
   }
@@ -293,7 +294,7 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
     if (!wifi_ok || cfg_spoolman_base[0] == '\0') {
       if (lbl_extra_fields_status) {
         lv_label_set_text(lbl_extra_fields_status, T(STR_EXTRA_FIELDS_NO_WIFI));
-        lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0xff8080), 0);
+        lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_DANGER_TEXT), 0);
       }
       return;
     }
@@ -302,19 +303,19 @@ void buildExtraFieldsScreen(bool is_setup_flow) {
     if (lbl_extra_fields_status) {
       if (code == 200 || code == 201) {
         { char sb[96]; backendText(T(STR_EF_TEST_CREATED), sb, sizeof(sb)); lv_label_set_text(lbl_extra_fields_status, sb); }
-        lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0xf0b838), 0);
+        lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_WARNING), 0);
       } else if (code == 409) {
         { char sb[96]; backendText(T(STR_EF_TEST_EXISTS), sb, sizeof(sb)); lv_label_set_text(lbl_extra_fields_status, sb); }
-        lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0xf0b838), 0);
+        lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_WARNING), 0);
       } else {
         lv_label_set_text(lbl_extra_fields_status, T(STR_EF_TEST_FAIL));
-        lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0xff8080), 0);
+        lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_DANGER_TEXT), 0);
       }
     }
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_test = lv_label_create(btn_test);
   lv_label_set_text(lbl_test, T(STR_EF_TEST_BTN));
-  lv_obj_set_style_text_color(lbl_test, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_test, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_test, &lv_font_montserrat_ext_14, 0);
   lv_obj_center(lbl_test);
 }
@@ -325,17 +326,17 @@ void checkAndCreateExtraFields(bool create_missing) {
 
   if (!wifi_ok) {
     lv_label_set_text(lbl_extra_fields_status, T(STR_EXTRA_FIELDS_NO_WIFI));
-    lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_DANGER_TEXT), 0);
     return;
   }
   if (cfg_spoolman_base[0] == '\0' || strcmp(cfg_spoolman_base, "http://") == 0) {
     { char sb[64]; backendText(T(STR_EXTRA_FIELDS_NO_SPOOLMAN), sb, sizeof(sb)); lv_label_set_text(lbl_extra_fields_status, sb); }
-    lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_DANGER_TEXT), 0);
     return;
   }
 
   lv_label_set_text(lbl_extra_fields_status, T(STR_EXTRA_FIELDS_CHECKING));
-  lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_TEXT_MUTED), 0);
   if (btn_extra_fields_create) lv_obj_add_flag(btn_extra_fields_create, LV_OBJ_FLAG_HIDDEN);
   lv_timer_handler();
   yield();
@@ -356,7 +357,7 @@ void checkAndCreateExtraFields(bool create_missing) {
     char buf[96];
     backendText(T(STR_SPOOLMAN_FAIL), buf, sizeof(buf));
     lv_label_set_text(lbl_extra_fields_status, buf);
-    lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_DANGER_TEXT), 0);
     return;
   }
 
@@ -389,19 +390,19 @@ void checkAndCreateExtraFields(bool create_missing) {
   if (missing_count == 0) {
     // All OK
     lv_label_set_text(lbl_extra_fields_status, T(STR_EXTRA_FIELDS_ALL_OK));
-    lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0x40c080), 0);
+    lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_SUCCESS_TEXT), 0);
     if (btn_extra_fields_create) lv_obj_add_flag(btn_extra_fields_create, LV_OBJ_FLAG_HIDDEN);
     // Turn skip/next button green with "Next →" label
     if (btn_extra_fields_next) {
-      lv_obj_set_style_bg_color(btn_extra_fields_next, lv_color_hex(0x1a3020), 0);
-      lv_obj_set_style_bg_color(btn_extra_fields_next, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
-      lv_obj_set_style_border_color(btn_extra_fields_next, lv_color_hex(0x2a5030), 0);
+      lv_obj_set_style_bg_color(btn_extra_fields_next, tc(TH_OK_BG), 0);
+      lv_obj_set_style_bg_color(btn_extra_fields_next, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
+      lv_obj_set_style_border_color(btn_extra_fields_next, tc(TH_SUCCESS_BG), 0);
       lv_obj_t *lbl = lv_obj_get_child(btn_extra_fields_next, 0);
       if (lbl) {
         char next_lbl[32];
         snprintf(next_lbl, sizeof(next_lbl), "%s  " LV_SYMBOL_RIGHT, T(STR_CONFIRM));
         lv_label_set_text(lbl, next_lbl);
-        lv_obj_set_style_text_color(lbl, lv_color_hex(0x40c080), 0);
+        lv_obj_set_style_text_color(lbl, tc(TH_SUCCESS_TEXT), 0);
       }
     }
     Serial.println("Extra fields: all present");
@@ -412,14 +413,14 @@ void checkAndCreateExtraFields(bool create_missing) {
     char status_buf[128];
     snprintf(status_buf, sizeof(status_buf), T(STR_EXTRA_FIELDS_MISSING), missing_buf);
     lv_label_set_text(lbl_extra_fields_status, status_buf);
-    lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0xf0b838), 0);
+    lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_WARNING), 0);
     if (btn_extra_fields_create) lv_obj_clear_flag(btn_extra_fields_create, LV_OBJ_FLAG_HIDDEN);
     return;
   }
 
   // Create missing fields
   lv_label_set_text(lbl_extra_fields_status, T(STR_EXTRA_FIELDS_CREATING));
-  lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_TEXT_MUTED), 0);
   lv_timer_handler();
   yield();
 
@@ -444,7 +445,7 @@ void checkAndCreateExtraFields(bool create_missing) {
     char fail_buf[128];
     snprintf(fail_buf, sizeof(fail_buf), T(STR_EXTRA_FIELDS_CREATE_FAIL), fail_fields);
     lv_label_set_text(lbl_extra_fields_status, fail_buf);
-    lv_obj_set_style_text_color(lbl_extra_fields_status, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_extra_fields_status, tc(TH_DANGER_TEXT), 0);
   } else {
     if (btn_extra_fields_create) lv_obj_add_flag(btn_extra_fields_create, LV_OBJ_FLAG_HIDDEN);
     yield();

--- a/src/ui/factor_screen.cpp
+++ b/src/ui/factor_screen.cpp
@@ -15,6 +15,7 @@
 #include "services/prefs_store.h"
 #include "services/user_options.h"
 #include "ui_common.h"
+#include "theme.h"
 
 
 void resetActivityTimer();
@@ -56,7 +57,7 @@ void buildFactorScreen() {
   lv_obj_set_style_border_width(scr_factor, 0, 0);
   lv_obj_set_style_pad_all(scr_factor, 0, 0);
   lv_obj_clear_flag(scr_factor, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr_factor, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_factor, tc(TH_BG), 0);
 
   // Crash protection: null label pointers (screen is rebuilt)
   lbl_factor_display = nullptr;
@@ -74,7 +75,7 @@ void buildFactorScreen() {
   // Description / hint — single line, compact
   lv_obj_t *lbl_desc = lv_label_create(scr_factor);
   lv_label_set_text(lbl_desc, T(STR_CAL_TARE_HINT));
-  lv_obj_set_style_text_color(lbl_desc, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_desc, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_desc, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(lbl_desc, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_desc, LV_LABEL_LONG_WRAP);
@@ -84,19 +85,19 @@ void buildFactorScreen() {
   // Single status row: "Scale: <value>" left | "Factor: --" right
   lv_obj_t *lbl_cal_w_title = lv_label_create(scr_factor);
   lv_label_set_text(lbl_cal_w_title, T(STR_LBL_SCALE));
-  lv_obj_set_style_text_color(lbl_cal_w_title, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_cal_w_title, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_cal_w_title, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(lbl_cal_w_title, 12, 78);
 
   lbl_factor_cal_weight = lv_label_create(scr_factor);
   lv_label_set_text(lbl_factor_cal_weight, "-- g");
-  lv_obj_set_style_text_color(lbl_factor_cal_weight, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_factor_cal_weight, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_factor_cal_weight, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(lbl_factor_cal_weight, 56, 78);
 
   lbl_factor_result = lv_label_create(scr_factor);
   lv_label_set_text(lbl_factor_result, T(STR_CAL_FACTOR));
-  lv_obj_set_style_text_color(lbl_factor_result, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_factor_result, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_factor_result, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(lbl_factor_result, LV_TEXT_ALIGN_RIGHT, 0);
   lv_obj_set_width(lbl_factor_result, 220);
@@ -106,8 +107,8 @@ void buildFactorScreen() {
   lv_obj_t *input_box_f = lv_obj_create(scr_factor);
   lv_obj_set_size(input_box_f, 260, 34);
   lv_obj_align(input_box_f, LV_ALIGN_TOP_MID, 0, 94);
-  lv_obj_set_style_bg_color(input_box_f, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_border_color(input_box_f, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_bg_color(input_box_f, tc(TH_SURFACE), 0);
+  lv_obj_set_style_border_color(input_box_f, tc(TH_ACCENT), 0);
   lv_obj_set_style_border_width(input_box_f, 1, 0);
   lv_obj_set_style_radius(input_box_f, 6, 0);
   lv_obj_set_style_pad_all(input_box_f, 0, 0);
@@ -115,7 +116,7 @@ void buildFactorScreen() {
 
   lbl_factor_display = lv_label_create(input_box_f);
   lv_label_set_text(lbl_factor_display, "_");
-  lv_obj_set_style_text_color(lbl_factor_display, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_factor_display, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_factor_display, &lv_font_montserrat_ext_20, 0);
   lv_obj_set_style_text_align(lbl_factor_display, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_center(lbl_factor_display);
@@ -137,13 +138,13 @@ void buildFactorScreen() {
     lv_obj_set_style_radius(btn_wg, 8, 0);
     lv_obj_set_style_shadow_width(btn_wg, 0, 0);
     lv_obj_set_style_border_width(btn_wg, 1, 0);
-    lv_obj_set_style_bg_color(btn_wg, g_whole_gram ? lv_color_hex(0x1a3020) : lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_border_color(btn_wg, g_whole_gram ? lv_color_hex(0x28d49a) : lv_color_hex(0x1a2840), 0);
-    lv_obj_set_style_bg_color(btn_wg, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_wg, g_whole_gram ? tc(TH_OK_BG) : tc(TH_SURFACE), 0);
+    lv_obj_set_style_border_color(btn_wg, g_whole_gram ? tc(TH_ACCENT) : tc(TH_SURFACE_3), 0);
+    lv_obj_set_style_bg_color(btn_wg, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
 
     lv_obj_t *lbl_wg = lv_label_create(btn_wg);
     lv_label_set_text(lbl_wg, T(STR_WHOLE_GRAM));
-    lv_obj_set_style_text_color(lbl_wg, g_whole_gram ? lv_color_hex(0x28d49a) : lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl_wg, g_whole_gram ? tc(TH_ACCENT) : tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl_wg, &lv_font_montserrat_ext_12, 0);
     lv_obj_set_style_text_align(lbl_wg, LV_TEXT_ALIGN_CENTER, 0);
     lv_label_set_long_mode(lbl_wg, LV_LABEL_LONG_WRAP);
@@ -155,9 +156,9 @@ void buildFactorScreen() {
       prefsPutBool("whole_gram", g_whole_gram);
       lv_obj_t *b = lv_event_get_target(e);
       lv_obj_t *l = lv_obj_get_child(b, 0);
-      lv_obj_set_style_bg_color(b, g_whole_gram ? lv_color_hex(0x1a3020) : lv_color_hex(0x0a1828), 0);
-      lv_obj_set_style_border_color(b, g_whole_gram ? lv_color_hex(0x28d49a) : lv_color_hex(0x1a2840), 0);
-      lv_obj_set_style_text_color(l, g_whole_gram ? lv_color_hex(0x28d49a) : lv_color_hex(0x4a6fa0), 0);
+      lv_obj_set_style_bg_color(b, g_whole_gram ? tc(TH_OK_BG) : tc(TH_SURFACE), 0);
+      lv_obj_set_style_border_color(b, g_whole_gram ? tc(TH_ACCENT) : tc(TH_SURFACE_3), 0);
+      lv_obj_set_style_text_color(l, g_whole_gram ? tc(TH_ACCENT) : tc(TH_TEXT_MUTED), 0);
     }, LV_EVENT_CLICKED, NULL);
   }
 
@@ -191,19 +192,19 @@ void buildFactorScreen() {
       }, LV_EVENT_CLICKED, NULL);
       lv_obj_t *lbl = lv_label_create(btn);
       lv_label_set_text(lbl, LV_SYMBOL_REFRESH "TARE");
-      lv_obj_set_style_text_color(lbl, lv_color_hex(0xf0b838), 0);
+      lv_obj_set_style_text_color(lbl, tc(TH_WARNING), 0);
       lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_14, 0);
       lv_obj_center(lbl);
     } else {
-      lv_obj_set_style_bg_color(btn, lv_color_hex(0x0a1828), 0);
-      lv_obj_set_style_bg_color(btn, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+      lv_obj_set_style_bg_color(btn, tc(TH_SURFACE), 0);
+      lv_obj_set_style_bg_color(btn, tc(TH_SURFACE_2), LV_STATE_PRESSED);
       lv_obj_set_style_radius(btn, 6, 0);
       lv_obj_set_style_shadow_width(btn, 0, 0);
       lv_obj_set_style_border_width(btn, 1, 0);
-      lv_obj_set_style_border_color(btn, lv_color_hex(0x1a2840), 0);
+      lv_obj_set_style_border_color(btn, tc(TH_SURFACE_3), 0);
       lv_obj_t *lbl = lv_label_create(btn);
       lv_label_set_text(lbl, np_labels_f[i]);
-      lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+      lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
       lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_16, 0);
       lv_obj_center(lbl);
       lv_obj_add_event_cb(btn, [](lv_event_t *e) {
@@ -223,12 +224,12 @@ void buildFactorScreen() {
   lv_obj_t *btn_del_f = lv_btn_create(scr_factor);
   lv_obj_set_size(btn_del_f, bw5_f, NP_H);
   lv_obj_set_pos(btn_del_f, NP_PAD_X, by5_f);
-  lv_obj_set_style_bg_color(btn_del_f, lv_color_hex(0x1a2030), 0);
+  lv_obj_set_style_bg_color(btn_del_f, tc(TH_SURFACE_DARK), 0);
   lv_obj_set_style_bg_color(btn_del_f, lv_color_hex(0x2a3040), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_del_f, 6, 0);
   lv_obj_set_style_shadow_width(btn_del_f, 0, 0);
   lv_obj_set_style_border_width(btn_del_f, 1, 0);
-  lv_obj_set_style_border_color(btn_del_f, lv_color_hex(0x1a2840), 0);
+  lv_obj_set_style_border_color(btn_del_f, tc(TH_SURFACE_3), 0);
   lv_obj_add_event_cb(btn_del_f, [](lv_event_t *e) {
     if (!lbl_factor_display) return;
     int len = strlen(factor_input);
@@ -237,19 +238,19 @@ void buildFactorScreen() {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_del_f = lv_label_create(btn_del_f);
   lv_label_set_text(lbl_del_f, LV_SYMBOL_BACKSPACE);
-  lv_obj_set_style_text_color(lbl_del_f, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_del_f, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_del_f, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_del_f);
 
   lv_obj_t *btn_ok_f = lv_btn_create(scr_factor);
   lv_obj_set_size(btn_ok_f, bw5_f, NP_H);
   lv_obj_set_pos(btn_ok_f, NP_PAD_X + bw5_f + NP_GAP, by5_f);
-  lv_obj_set_style_bg_color(btn_ok_f, lv_color_hex(0x1a3020), 0);
-  lv_obj_set_style_bg_color(btn_ok_f, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_ok_f, tc(TH_OK_BG), 0);
+  lv_obj_set_style_bg_color(btn_ok_f, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_ok_f, 6, 0);
   lv_obj_set_style_shadow_width(btn_ok_f, 0, 0);
   lv_obj_set_style_border_width(btn_ok_f, 1, 0);
-  lv_obj_set_style_border_color(btn_ok_f, lv_color_hex(0x2a5030), 0);
+  lv_obj_set_style_border_color(btn_ok_f, tc(TH_SUCCESS_BG), 0);
   lv_obj_add_event_cb(btn_ok_f, [](lv_event_t *e) {
     if (!lbl_factor_result) return;
     float known_g = atof(factor_input);
@@ -268,7 +269,7 @@ void buildFactorScreen() {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_ok2_f = lv_label_create(btn_ok_f);
   lv_label_set_text(lbl_ok2_f, T(STR_BTN_CALCULATE));
-  lv_obj_set_style_text_color(lbl_ok2_f, lv_color_hex(0x40c080), 0);
+  lv_obj_set_style_text_color(lbl_ok2_f, tc(TH_SUCCESS_TEXT), 0);
   lv_obj_set_style_text_font(lbl_ok2_f, &lv_font_montserrat_ext_14, 0);
   lv_obj_center(lbl_ok2_f);
 }

--- a/src/ui/filaman_options_screen.cpp
+++ b/src/ui/filaman_options_screen.cpp
@@ -12,6 +12,7 @@
 #include "services/prefs_store.h"
 #include "services/user_options.h"
 #include "ui_common.h"
+#include "theme.h"
 
 
 void buildFilaManOptionsScreen() {
@@ -52,7 +53,7 @@ void buildFilaManOptionsScreen() {
       buf_v[sizeof(buf_v)-1] = '\0';
       lv_label_set_text(arr_lbl, buf_v);
       lv_obj_set_style_text_color(arr_lbl,
-        g_flm_autolink ? lv_color_hex(0x28d49a) : lv_color_hex(0x4a6fa0), 0);
+        g_flm_autolink ? tc(TH_ACCENT) : tc(TH_TEXT_MUTED), 0);
       lv_obj_set_style_text_font(arr_lbl, &lv_font_montserrat_ext_14, 0);
     }
 

--- a/src/ui/header_status.cpp
+++ b/src/ui/header_status.cpp
@@ -8,13 +8,14 @@
 
 #include "services/user_options.h"
 #include "services/wifi_manager.h"
+#include "theme.h"
 
 
 static lv_color_t wifiColor() {
   if (!wifi_ok) return lv_color_hex(0xe04040);
   int rssi = wifiManagerRSSI();
-  if (rssi >= -65) return lv_color_hex(0x28d49a);
-  if (rssi >= -75) return lv_color_hex(0xf0b838);
+  if (rssi >= -65) return tc(TH_ACCENT);
+  if (rssi >= -75) return tc(TH_WARNING);
   return lv_color_hex(0xe06020);
 }
 
@@ -26,13 +27,13 @@ void updateHeaderStatus() {
   if (lbl_hdr_nfc) {
     lv_label_set_text(lbl_hdr_nfc, nfc_ok ? "NFC" : "NFC!");
     lv_obj_set_style_text_color(lbl_hdr_nfc,
-      nfc_ok ? lv_color_hex(0x28d49a) : lv_color_hex(0xe04040), 0);
+      nfc_ok ? tc(TH_ACCENT) : lv_color_hex(0xe04040), 0);
   }
 
   if (lbl_hdr_scl) {
     lv_label_set_text(lbl_hdr_scl, scl_ok ? "SCL" : "SCL!");
     lv_obj_set_style_text_color(lbl_hdr_scl,
-      scl_ok ? lv_color_hex(0x28d49a) : lv_color_hex(0xe04040), 0);
+      scl_ok ? tc(TH_ACCENT) : lv_color_hex(0xe04040), 0);
   }
 
   // Both labels follow the active backend. Set here rather than only at build
@@ -40,7 +41,7 @@ void updateHeaderStatus() {
   if (lbl_hdr_sm) {
     lv_label_set_text(lbl_hdr_sm, backendIsFilaMan() ? "FLM" : "SPM");
     lv_obj_set_style_text_color(lbl_hdr_sm,
-      sm_reachable ? lv_color_hex(0x28d49a) : lv_color_hex(0xe04040), 0);
+      sm_reachable ? tc(TH_ACCENT) : lv_color_hex(0xe04040), 0);
   }
 
   if (lbl_sm_cap) {

--- a/src/ui/info_screen.cpp
+++ b/src/ui/info_screen.cpp
@@ -10,6 +10,7 @@
 #include "hardware/sd_logger.h"
 #include "lang.h"
 #include "extra/libs/qrcode/lv_qrcode.h"
+#include "theme.h"
 
 
 
@@ -46,7 +47,7 @@ void showQRPopup(int idx) {
   lv_obj_t *popup = lv_obj_create(lv_scr_act());
   lv_obj_set_size(popup, 480, 320);
   lv_obj_set_pos(popup, 0, 0);
-  lv_obj_set_style_bg_color(popup, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(popup, tc(TH_BG), 0);
   lv_obj_set_style_border_width(popup, 0, 0);
   lv_obj_set_style_radius(popup, 0, 0);
   lv_obj_set_style_pad_all(popup, 0, 0);
@@ -55,14 +56,14 @@ void showQRPopup(int idx) {
   lv_obj_t *btn_back = lv_btn_create(popup);
   lv_obj_set_size(btn_back, 44, 44);
   lv_obj_set_pos(btn_back, 4, 2);
-  lv_obj_set_style_bg_color(btn_back, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_back, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_back, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_back, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_back, 8, 0);
   lv_obj_set_style_shadow_width(btn_back, 0, 0);
   lv_obj_set_style_border_width(btn_back, 0, 0);
   lv_obj_t *lbl_bk = lv_label_create(btn_back);
   lv_label_set_text(lbl_bk, LV_SYMBOL_LEFT);
-  lv_obj_set_style_text_color(lbl_bk, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_bk, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_bk, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_bk);
   lv_obj_add_event_cb(btn_back, [](lv_event_t *e){
@@ -71,21 +72,21 @@ void showQRPopup(int idx) {
 
   lv_obj_t *lbl_title = lv_label_create(popup);
   lv_label_set_text(lbl_title, QR_TITLES[idx]);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 12);
 
   lv_obj_t *btn_x = lv_btn_create(popup);
   lv_obj_set_size(btn_x, 44, 44);
   lv_obj_align(btn_x, LV_ALIGN_TOP_RIGHT, -4, 2);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_x, 8, 0);
   lv_obj_set_style_shadow_width(btn_x, 0, 0);
   lv_obj_set_style_border_width(btn_x, 0, 0);
   lv_obj_t *lbl_x = lv_label_create(btn_x);
   lv_label_set_text(lbl_x, LV_SYMBOL_CLOSE);
-  lv_obj_set_style_text_color(lbl_x, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_x, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_x, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_x);
   lv_obj_add_event_cb(btn_x, [](lv_event_t *e){
@@ -96,7 +97,7 @@ void showQRPopup(int idx) {
 
   lv_obj_t *lbl_desc = lv_label_create(popup);
   lv_label_set_text(lbl_desc, getQRDesc(idx));
-  lv_obj_set_style_text_color(lbl_desc, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_desc, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_desc, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_desc, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_desc, LV_LABEL_LONG_WRAP);
@@ -105,7 +106,7 @@ void showQRPopup(int idx) {
 
   lv_obj_t *lbl_url = lv_label_create(popup);
   lv_label_set_text(lbl_url, QR_URLS_DISPLAY[idx]);
-  lv_obj_set_style_text_color(lbl_url, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_url, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_url, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_url, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_url, LV_ALIGN_TOP_MID, 0, 84);
@@ -113,7 +114,7 @@ void showQRPopup(int idx) {
   size_t url_len = strlen(QR_URLS[idx]);
   logSDf("QR: %s about to create url_len=%u heap=%d PSRAM=%d",
     names[idx], (unsigned)url_len, ESP.getFreeHeap(), ESP.getFreePsram());
-  lv_obj_t *qr = lv_qrcode_create(popup, 160, lv_color_hex(0x000000), lv_color_hex(0xffffff));
+  lv_obj_t *qr = lv_qrcode_create(popup, 160, tc(TH_BLACK), lv_color_hex(0xffffff));
   logSDf("QR: %s create OK heap=%d", names[idx], ESP.getFreeHeap());
   lv_res_t qr_res = lv_qrcode_update(qr, QR_URLS[idx], url_len);
   logSDf("QR: %s update done res=%d heap=%d", names[idx], (int)qr_res, ESP.getFreeHeap());
@@ -128,7 +129,7 @@ void showInfoScreen() {
   scr_info = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr_info, 480, 320);
   lv_obj_set_pos(scr_info, 0, 0);
-  lv_obj_set_style_bg_color(scr_info, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_info, tc(TH_BG), 0);
   lv_obj_set_style_border_width(scr_info, 0, 0);
   lv_obj_set_style_radius(scr_info, 0, 0);
   lv_obj_set_style_pad_all(scr_info, 0, 0);
@@ -137,14 +138,14 @@ void showInfoScreen() {
   lv_obj_t *btn_back = lv_btn_create(scr_info);
   lv_obj_set_size(btn_back, 44, 44);
   lv_obj_set_pos(btn_back, 4, 2);
-  lv_obj_set_style_bg_color(btn_back, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_back, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_back, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_back, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_back, 8, 0);
   lv_obj_set_style_shadow_width(btn_back, 0, 0);
   lv_obj_set_style_border_width(btn_back, 0, 0);
   lv_obj_t *lbl_bk = lv_label_create(btn_back);
   lv_label_set_text(lbl_bk, LV_SYMBOL_LEFT);
-  lv_obj_set_style_text_color(lbl_bk, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_bk, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_bk, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_bk);
   lv_obj_add_event_cb(btn_back, [](lv_event_t *e){
@@ -154,21 +155,21 @@ void showInfoScreen() {
 
   lv_obj_t *hdr = lv_label_create(scr_info);
   lv_label_set_text(hdr, T(STR_BTN_INFO));
-  lv_obj_set_style_text_color(hdr, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(hdr, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(hdr, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(hdr, LV_ALIGN_TOP_MID, 0, 12);
 
   lv_obj_t *btn_x = lv_btn_create(scr_info);
   lv_obj_set_size(btn_x, 44, 44);
   lv_obj_align(btn_x, LV_ALIGN_TOP_RIGHT, -4, 2);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_x, 8, 0);
   lv_obj_set_style_shadow_width(btn_x, 0, 0);
   lv_obj_set_style_border_width(btn_x, 0, 0);
   lv_obj_t *lbl_x = lv_label_create(btn_x);
   lv_label_set_text(lbl_x, LV_SYMBOL_CLOSE);
-  lv_obj_set_style_text_color(lbl_x, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_x, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_x, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_x);
   lv_obj_add_event_cb(btn_x, [](lv_event_t *e){
@@ -180,7 +181,7 @@ void showInfoScreen() {
   char ver_buf[40];
   snprintf(ver_buf, sizeof(ver_buf), T(STR_INFO_VERSION), FW_VERSION);
   lv_label_set_text(ver_lbl, ver_buf);
-  lv_obj_set_style_text_color(ver_lbl, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(ver_lbl, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(ver_lbl, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(ver_lbl, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(ver_lbl, LV_ALIGN_TOP_MID, 0, 54);
@@ -188,8 +189,8 @@ void showInfoScreen() {
   const int QB_W = 228, QB_H = 90, QB_GAP = 8;
   const int QB_X0 = (480 - 2*QB_W - QB_GAP) / 2;
   const int QB_Y0 = 82;
-  static const uint32_t QB_COLS[] = { 0x1a2800, 0x0a1828, 0x12103a, 0x1a0a18 };
-  static const uint32_t QB_TEXT[] = { 0xa0d840, 0x28d49a, 0x8090ff, 0xc060e0 };
+  const uint32_t QB_COLS[] = { 0x1a2800, g_theme[TH_SURFACE], 0x12103a, 0x1a0a18 };
+  const uint32_t QB_TEXT[] = { 0xa0d840, g_theme[TH_ACCENT], 0x8090ff, 0xc060e0 };
 
   lv_obj_t *btn_kofi = lv_btn_create(scr_info);
   lv_obj_set_size(btn_kofi, QB_W, QB_H);
@@ -266,14 +267,14 @@ void showInfoScreen() {
   lv_obj_t *disc = lv_label_create(scr_info);
   { char db[64]; strncpy(db, T(STR_NOT_AFFILIATED), sizeof(db) - 1); db[sizeof(db) - 1] = '\0';
     lv_label_set_text(disc, db); }
-  lv_obj_set_style_text_color(disc, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(disc, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(disc, &lv_font_montserrat_ext_10, 0);
   lv_obj_set_style_text_align(disc, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(disc, LV_ALIGN_BOTTOM_MID, 0, -6);
 
   lv_obj_t *hint = lv_label_create(scr_info);
   lv_label_set_text(hint, T(STR_INFO_HINT));
-  lv_obj_set_style_text_color(hint, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(hint, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(hint, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(hint, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(hint, LV_ALIGN_BOTTOM_MID, 0, -22);

--- a/src/ui/language_screen.cpp
+++ b/src/ui/language_screen.cpp
@@ -8,6 +8,7 @@
 #include "lang.h"
 #include "services/prefs_store.h"
 #include "reboot_popup.h"
+#include "theme.h"
 
 
 void showLanguageScreen() {
@@ -16,7 +17,7 @@ void showLanguageScreen() {
   lv_obj_t *scr = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr, 480, 320);
   lv_obj_set_pos(scr, 0, 0);
-  lv_obj_set_style_bg_color(scr, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr, tc(TH_BG), 0);
   lv_obj_set_style_border_width(scr, 0, 0);
   lv_obj_set_style_radius(scr, 0, 0);
   lv_obj_set_style_pad_all(scr, 0, 0);
@@ -25,14 +26,14 @@ void showLanguageScreen() {
   lv_obj_t *btn_back = lv_btn_create(scr);
   lv_obj_set_size(btn_back, 44, 44);
   lv_obj_set_pos(btn_back, 4, 2);
-  lv_obj_set_style_bg_color(btn_back, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_back, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_back, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_back, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_back, 8, 0);
   lv_obj_set_style_shadow_width(btn_back, 0, 0);
   lv_obj_set_style_border_width(btn_back, 0, 0);
   lv_obj_t *lbl_bk = lv_label_create(btn_back);
   lv_label_set_text(lbl_bk, LV_SYMBOL_LEFT);
-  lv_obj_set_style_text_color(lbl_bk, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_bk, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_bk, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_bk);
   lv_obj_add_event_cb(btn_back, [](lv_event_t *e){
@@ -41,21 +42,21 @@ void showLanguageScreen() {
 
   lv_obj_t *hdr = lv_label_create(scr);
   lv_label_set_text(hdr, "Language / Sprache");
-  lv_obj_set_style_text_color(hdr, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(hdr, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(hdr, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(hdr, LV_ALIGN_TOP_MID, 0, 12);
 
   lv_obj_t *btn_x = lv_btn_create(scr);
   lv_obj_set_size(btn_x, 44, 44);
   lv_obj_align(btn_x, LV_ALIGN_TOP_RIGHT, -4, 2);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_x, 8, 0);
   lv_obj_set_style_shadow_width(btn_x, 0, 0);
   lv_obj_set_style_border_width(btn_x, 0, 0);
   lv_obj_t *lbl_x = lv_label_create(btn_x);
   lv_label_set_text(lbl_x, LV_SYMBOL_CLOSE);
-  lv_obj_set_style_text_color(lbl_x, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_x, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_x, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_x);
   lv_obj_add_event_cb(btn_x, [](lv_event_t *e){
@@ -66,7 +67,7 @@ void showLanguageScreen() {
 
   lv_obj_t *hint = lv_label_create(scr);
   lv_label_set_text(hint, T(STR_LANG_HINT));
-  lv_obj_set_style_text_color(hint, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(hint, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(hint, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(hint, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(hint, LV_LABEL_LONG_WRAP);
@@ -79,14 +80,14 @@ void showLanguageScreen() {
   lv_obj_set_size(btn_de, LB_W, LB_H);
   lv_obj_set_pos(btn_de, 8, LB_Y0);
   bool de_active = (g_lang == LANG_DE);
-  lv_obj_set_style_bg_color(btn_de, lv_color_hex(de_active ? 0x0a2a40 : 0x0a1828), 0);
+  lv_obj_set_style_bg_color(btn_de, lv_color_hex(de_active ? 0x0a2a40 : g_theme[TH_SURFACE]), 0);
   lv_obj_set_style_radius(btn_de, 10, 0);
   lv_obj_set_style_shadow_width(btn_de, 0, 0);
   lv_obj_set_style_border_width(btn_de, 2, 0);
-  lv_obj_set_style_border_color(btn_de, lv_color_hex(de_active ? 0x28d49a : 0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_de, lv_color_hex(de_active ? g_theme[TH_ACCENT] : g_theme[TH_SURFACE_2]), 0);
   lv_obj_t *lbl_de = lv_label_create(btn_de);
   lv_label_set_text(lbl_de, "DE   Deutsch");
-  lv_obj_set_style_text_color(lbl_de, lv_color_hex(de_active ? 0x28d49a : 0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_de, lv_color_hex(de_active ? g_theme[TH_ACCENT] : g_theme[TH_TEXT_MUTED]), 0);
   lv_obj_set_style_text_font(lbl_de, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_de);
   lv_obj_add_event_cb(btn_de, [](lv_event_t *e){
@@ -100,14 +101,14 @@ void showLanguageScreen() {
   lv_obj_set_size(btn_en, LB_W, LB_H);
   lv_obj_set_pos(btn_en, 254, LB_Y0);
   bool en_active = (g_lang == LANG_EN);
-  lv_obj_set_style_bg_color(btn_en, lv_color_hex(en_active ? 0x0a2a40 : 0x0a1828), 0);
+  lv_obj_set_style_bg_color(btn_en, lv_color_hex(en_active ? 0x0a2a40 : g_theme[TH_SURFACE]), 0);
   lv_obj_set_style_radius(btn_en, 10, 0);
   lv_obj_set_style_shadow_width(btn_en, 0, 0);
   lv_obj_set_style_border_width(btn_en, 2, 0);
-  lv_obj_set_style_border_color(btn_en, lv_color_hex(en_active ? 0x28d49a : 0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_en, lv_color_hex(en_active ? g_theme[TH_ACCENT] : g_theme[TH_SURFACE_2]), 0);
   lv_obj_t *lbl_en = lv_label_create(btn_en);
   lv_label_set_text(lbl_en, "EN   English");
-  lv_obj_set_style_text_color(lbl_en, lv_color_hex(en_active ? 0x28d49a : 0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_en, lv_color_hex(en_active ? g_theme[TH_ACCENT] : g_theme[TH_TEXT_MUTED]), 0);
   lv_obj_set_style_text_font(lbl_en, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_en);
   lv_obj_add_event_cb(btn_en, [](lv_event_t *e){
@@ -119,7 +120,7 @@ void showLanguageScreen() {
 
   lv_obj_t *lbl_date = lv_label_create(scr);
   lv_label_set_text(lbl_date, T(STR_DATE_FMT_LABEL));
-  lv_obj_set_style_text_color(lbl_date, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_date, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_date, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_pos(lbl_date, 12, 158);
 
@@ -129,14 +130,14 @@ void showLanguageScreen() {
   lv_obj_set_size(btn_dmy, DB_W, DB_H);
   lv_obj_set_pos(btn_dmy, 8, DB_Y);
   bool dmy_active = (g_date_fmt == 0);
-  lv_obj_set_style_bg_color(btn_dmy, lv_color_hex(dmy_active ? 0x0a2a40 : 0x0a1828), 0);
+  lv_obj_set_style_bg_color(btn_dmy, lv_color_hex(dmy_active ? 0x0a2a40 : g_theme[TH_SURFACE]), 0);
   lv_obj_set_style_radius(btn_dmy, 10, 0);
   lv_obj_set_style_shadow_width(btn_dmy, 0, 0);
   lv_obj_set_style_border_width(btn_dmy, 2, 0);
-  lv_obj_set_style_border_color(btn_dmy, lv_color_hex(dmy_active ? 0x28d49a : 0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_dmy, lv_color_hex(dmy_active ? g_theme[TH_ACCENT] : g_theme[TH_SURFACE_2]), 0);
   lv_obj_t *lbl_dmy = lv_label_create(btn_dmy);
   lv_label_set_text(lbl_dmy, "DD.MM.YYYY");
-  lv_obj_set_style_text_color(lbl_dmy, lv_color_hex(dmy_active ? 0x28d49a : 0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_dmy, lv_color_hex(dmy_active ? g_theme[TH_ACCENT] : g_theme[TH_TEXT_MUTED]), 0);
   lv_obj_set_style_text_font(lbl_dmy, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_dmy);
   lv_obj_add_event_cb(btn_dmy, [](lv_event_t *e){
@@ -149,14 +150,14 @@ void showLanguageScreen() {
   lv_obj_set_size(btn_iso, DB_W, DB_H);
   lv_obj_set_pos(btn_iso, 254, DB_Y);
   bool iso_active = (g_date_fmt == 1);
-  lv_obj_set_style_bg_color(btn_iso, lv_color_hex(iso_active ? 0x0a2a40 : 0x0a1828), 0);
+  lv_obj_set_style_bg_color(btn_iso, lv_color_hex(iso_active ? 0x0a2a40 : g_theme[TH_SURFACE]), 0);
   lv_obj_set_style_radius(btn_iso, 10, 0);
   lv_obj_set_style_shadow_width(btn_iso, 0, 0);
   lv_obj_set_style_border_width(btn_iso, 2, 0);
-  lv_obj_set_style_border_color(btn_iso, lv_color_hex(iso_active ? 0x28d49a : 0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_iso, lv_color_hex(iso_active ? g_theme[TH_ACCENT] : g_theme[TH_SURFACE_2]), 0);
   lv_obj_t *lbl_iso = lv_label_create(btn_iso);
   lv_label_set_text(lbl_iso, "YYYY-MM-DD");
-  lv_obj_set_style_text_color(lbl_iso, lv_color_hex(iso_active ? 0x28d49a : 0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_iso, lv_color_hex(iso_active ? g_theme[TH_ACCENT] : g_theme[TH_TEXT_MUTED]), 0);
   lv_obj_set_style_text_font(lbl_iso, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_iso);
   lv_obj_add_event_cb(btn_iso, [](lv_event_t *e){
@@ -167,7 +168,7 @@ void showLanguageScreen() {
 
   lv_obj_t *hint2 = lv_label_create(scr);
   lv_label_set_text(hint2, T(STR_LANG_HINT));
-  lv_obj_set_style_text_color(hint2, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(hint2, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(hint2, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(hint2, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(hint2, LV_ALIGN_BOTTOM_MID, 0, -8);

--- a/src/ui/last_used_screen.cpp
+++ b/src/ui/last_used_screen.cpp
@@ -14,6 +14,7 @@
 #include "services/user_options.h"
 #include "ui_common.h"
 #include "services/backend.h"
+#include "theme.h"
 
 
 
@@ -45,10 +46,10 @@ void buildLastUsedScreen() {
   lv_obj_set_size(btn_osm, 210, 50);
   lv_obj_set_pos(btn_osm, 12, 58);
   bool osm_active = (last_used_mode == 0);
-  lv_obj_set_style_bg_color(btn_osm, lv_color_hex(osm_active ? 0x1a3020 : 0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_osm, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_osm, lv_color_hex(osm_active ? g_theme[TH_OK_BG] : g_theme[TH_SURFACE]), 0);
+  lv_obj_set_style_bg_color(btn_osm, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
   lv_obj_set_style_border_width(btn_osm, 1, 0);
-  lv_obj_set_style_border_color(btn_osm, lv_color_hex(osm_active ? 0x28d49a : 0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_osm, lv_color_hex(osm_active ? g_theme[TH_ACCENT] : g_theme[TH_SURFACE_2]), 0);
   lv_obj_set_style_radius(btn_osm, 8, 0);
   lv_obj_set_style_shadow_width(btn_osm, 0, 0);
   lv_obj_add_event_cb(btn_osm, [](lv_event_t *e) {
@@ -63,7 +64,7 @@ void buildLastUsedScreen() {
   // where the same option reads FilaMan's own consumption field.
   lv_label_set_text(lbl_osm, backendIsFilaMan() ? T(STR_LASTUSED_OPT_FILAMAN)
                                                 : T(STR_LASTUSED_OPT_OSM));
-  lv_obj_set_style_text_color(lbl_osm, lv_color_hex(osm_active ? 0x40c080 : 0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_osm, lv_color_hex(osm_active ? g_theme[TH_SUCCESS_TEXT] : g_theme[TH_TEXT]), 0);
   lv_obj_set_style_text_font(lbl_osm, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_osm, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_osm, LV_ALIGN_CENTER, 0, 0);
@@ -72,10 +73,10 @@ void buildLastUsedScreen() {
   lv_obj_set_size(btn_lw, 210, 50);
   lv_obj_set_pos(btn_lw, 238, 58);
   bool lw_active = (last_used_mode == 1);
-  lv_obj_set_style_bg_color(btn_lw, lv_color_hex(lw_active ? 0x1a3020 : 0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_lw, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_lw, lv_color_hex(lw_active ? g_theme[TH_OK_BG] : g_theme[TH_SURFACE]), 0);
+  lv_obj_set_style_bg_color(btn_lw, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
   lv_obj_set_style_border_width(btn_lw, 1, 0);
-  lv_obj_set_style_border_color(btn_lw, lv_color_hex(lw_active ? 0x28d49a : 0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_lw, lv_color_hex(lw_active ? g_theme[TH_ACCENT] : g_theme[TH_SURFACE_2]), 0);
   lv_obj_set_style_radius(btn_lw, 8, 0);
   lv_obj_set_style_shadow_width(btn_lw, 0, 0);
   lv_obj_add_event_cb(btn_lw, [](lv_event_t *e) {
@@ -87,7 +88,7 @@ void buildLastUsedScreen() {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_lw = lv_label_create(btn_lw);
   lv_label_set_text(lbl_lw, T(STR_LASTUSED_OPT_WEIGHED));
-  lv_obj_set_style_text_color(lbl_lw, lv_color_hex(lw_active ? 0x40c080 : 0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_lw, lv_color_hex(lw_active ? g_theme[TH_SUCCESS_TEXT] : g_theme[TH_TEXT]), 0);
   lv_obj_set_style_text_font(lbl_lw, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_lw, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_lw, LV_ALIGN_CENTER, 0, 0);
@@ -101,7 +102,7 @@ void buildLastUsedScreen() {
   char desc_buf[280];
   strncpy(desc_buf, desc, sizeof(desc_buf)-1); desc_buf[sizeof(desc_buf)-1] = 0;
   lv_label_set_text(lbl_desc, desc_buf);
-  lv_obj_set_style_text_color(lbl_desc, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_desc, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_desc, &lv_font_montserrat_ext_14, 0);
   lv_label_set_long_mode(lbl_desc, LV_LABEL_LONG_WRAP);
   lv_obj_set_width(lbl_desc, 448);

--- a/src/ui/main_screen.cpp
+++ b/src/ui/main_screen.cpp
@@ -24,6 +24,7 @@
 #include "ui/settings_screen.h"
 #include "ui/spool_flow.h"
 #include "ui_common.h"
+#include "theme.h"
 
 // ============================================================
 //  FILL DISPLAY WITH TAG DATA
@@ -34,9 +35,9 @@ void updateDisplay() {
 
   // Status bar: green dot + tag found
   lv_label_set_text(lbl_nfc_dot, LV_SYMBOL_BULLET);
-  lv_obj_set_style_text_color(lbl_nfc_dot, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_nfc_dot, tc(TH_ACCENT), 0);
   lv_label_set_text(lbl_status, T(STR_TAG_FOUND));
-  lv_obj_set_style_text_color(lbl_status, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_status, tc(TH_ACCENT), 0);
 
   // Material (Zone 3 Row A)
   lv_label_set_text(lbl_material,
@@ -44,7 +45,7 @@ void updateDisplay() {
 
   // SM-ID: shown as "?" until querySpoolman fills it
   lv_label_set_text(lbl_spoolman_id, "?");
-  lv_obj_set_style_text_color(lbl_spoolman_id, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_spoolman_id, tc(TH_WARNING), 0);
 
   // Filament name: cleared until Spoolman responds
   lv_label_set_text(lbl_filament_name, "");
@@ -87,14 +88,14 @@ void updateDisplay() {
 //  Zone 5: Buttons     y=264..319 (56px) [Update Weight] [Dried today] [Settings]
 // ============================================================
 void buildUI() {
-  lv_obj_set_style_bg_color(lv_scr_act(), lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(lv_scr_act(), tc(TH_BG), 0);
 
   // ── ZONE 1: Header y=0..25 (26px) ───────────────────────
   // Name+Version left | WiFi NFC right — scan counter moved to status bar
   lv_obj_t *hdr = lv_obj_create(lv_scr_act());
   lv_obj_set_size(hdr, 480, 26);
   lv_obj_set_pos(hdr, 0, 0);
-  lv_obj_set_style_bg_color(hdr, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(hdr, tc(TH_BG), 0);
   lv_obj_set_style_border_width(hdr, 0, 0);
   lv_obj_set_style_radius(hdr, 0, 0);
   lv_obj_set_style_pad_all(hdr, 0, 0);
@@ -102,14 +103,14 @@ void buildUI() {
 
   lv_obj_t *hdr_lbl = lv_label_create(hdr);
   lv_label_set_text(hdr_lbl, "SpoolmanScale " FW_VERSION);
-  lv_obj_set_style_text_color(hdr_lbl, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(hdr_lbl, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(hdr_lbl, &lv_font_montserrat_ext_12, 0);
   lv_obj_align(hdr_lbl, LV_ALIGN_LEFT_MID, 6, 0);
 
   // SD card indicator in header — only visible when sd_available
   lv_obj_t *lbl_sd_hdr = lv_label_create(hdr);
   lv_label_set_text(lbl_sd_hdr, LV_SYMBOL_SD_CARD);
-  lv_obj_set_style_text_color(lbl_sd_hdr, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_sd_hdr, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_sd_hdr, &lv_font_montserrat_ext_12, 0);
   lv_obj_align(lbl_sd_hdr, LV_ALIGN_RIGHT_MID, -120, 0);
   if (!sd_available) lv_obj_add_flag(lbl_sd_hdr, LV_OBJ_FLAG_HIDDEN);
@@ -145,7 +146,7 @@ void buildUI() {
   lv_obj_t *status_bar = lv_obj_create(lv_scr_act());
   lv_obj_set_size(status_bar, 480, 22);
   lv_obj_set_pos(status_bar, 0, 26);
-  lv_obj_set_style_bg_color(status_bar, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(status_bar, tc(TH_BG), 0);
   lv_obj_set_style_border_width(status_bar, 0, 0);
   lv_obj_set_style_radius(status_bar, 0, 0);
   lv_obj_set_style_pad_all(status_bar, 0, 0);
@@ -153,7 +154,7 @@ void buildUI() {
 
   lbl_nfc_dot = lv_label_create(status_bar);
   lv_label_set_text(lbl_nfc_dot, LV_SYMBOL_BULLET);
-  lv_obj_set_style_text_color(lbl_nfc_dot, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_nfc_dot, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_nfc_dot, &lv_font_montserrat_ext_14, 0);
   lv_obj_align(lbl_nfc_dot, LV_ALIGN_LEFT_MID, 6, 0);
 
@@ -172,7 +173,7 @@ void buildUI() {
   // according to g_ip_bar_mode, hidden while the mode is off.
   lbl_hdr_ip = lv_label_create(status_bar);
   lv_label_set_text(lbl_hdr_ip, "");
-  lv_obj_set_style_text_color(lbl_hdr_ip, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(lbl_hdr_ip, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(lbl_hdr_ip, &lv_font_montserrat_ext_12, 0);
   lv_obj_align(lbl_hdr_ip, LV_ALIGN_RIGHT_MID, -44, 0);
   lv_obj_add_flag(lbl_hdr_ip, LV_OBJ_FLAG_HIDDEN);
@@ -180,7 +181,7 @@ void buildUI() {
   // Scan counter: right side of status bar
   lbl_hdr_scans = lv_label_create(status_bar);
   lv_label_set_text(lbl_hdr_scans, "#0");
-  lv_obj_set_style_text_color(lbl_hdr_scans, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(lbl_hdr_scans, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(lbl_hdr_scans, &lv_font_montserrat_ext_12, 0);
   lv_obj_align(lbl_hdr_scans, LV_ALIGN_RIGHT_MID, -6, 0);
 
@@ -190,7 +191,7 @@ void buildUI() {
   lv_obj_t *sep1 = lv_obj_create(lv_scr_act());
   lv_obj_set_size(sep1, 480, 1);
   lv_obj_set_pos(sep1, 0, 48);
-  lv_obj_set_style_bg_color(sep1, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(sep1, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(sep1, 0, 0);
   lv_obj_set_style_radius(sep1, 0, 0);
   lv_obj_set_style_pad_all(sep1, 0, 0);
@@ -207,7 +208,7 @@ void buildUI() {
   lv_obj_set_pos(lbl_color_swatch, 8, 54);
   lv_obj_set_style_bg_color(lbl_color_swatch, lv_color_hex(0x333333), 0);
   lv_obj_set_style_radius(lbl_color_swatch, 6, 0);
-  lv_obj_set_style_border_color(lbl_color_swatch, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_border_color(lbl_color_swatch, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_border_width(lbl_color_swatch, 1, 0);
   lv_obj_set_style_pad_all(lbl_color_swatch, 0, 0);
   lv_obj_clear_flag(lbl_color_swatch, LV_OBJ_FLAG_SCROLLABLE);
@@ -215,21 +216,21 @@ void buildUI() {
   // Cap: ID (x=58, y=51)
   lv_obj_t *lbl_id_cap = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_id_cap, "ID");
-  lv_obj_set_style_text_color(lbl_id_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_id_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_id_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(lbl_id_cap, 58, 51);
 
   // SM-ID value (x=58, y=65)
   lbl_spoolman_id = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_spoolman_id, "?");
-  lv_obj_set_style_text_color(lbl_spoolman_id, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_spoolman_id, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_spoolman_id, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_pos(lbl_spoolman_id, 58, 65);
 
   // Cap: Material (x=92, y=51)
   lv_obj_t *lbl_mat_cap = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_mat_cap, "Material");
-  lv_obj_set_style_text_color(lbl_mat_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_mat_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_mat_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(lbl_mat_cap, 92, 51);
 
@@ -245,7 +246,7 @@ void buildUI() {
   // Cap: Filament (x=260, y=51)
   lv_obj_t *lbl_fil_cap = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_fil_cap, "Filament");
-  lv_obj_set_style_text_color(lbl_fil_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_fil_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_fil_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(lbl_fil_cap, 232, 51);  // Fix 5: slightly left
 
@@ -266,13 +267,13 @@ void buildUI() {
   // Row B: Vendor (x=8, y=98) | Temp (x=210, y=98) | More info btn TOP RIGHT bigger
   lv_obj_t *lbl_vendor_cap = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_vendor_cap, T(STR_LBL_VENDOR));
-  lv_obj_set_style_text_color(lbl_vendor_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_vendor_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_vendor_cap, &lv_font_montserrat_ext_14, 0);  // Fix 5: +1 size
   lv_obj_set_pos(lbl_vendor_cap, 8, 98);
 
   lbl_vendor = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_vendor, "-");
-  lv_obj_set_style_text_color(lbl_vendor, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_vendor, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_vendor, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_pos(lbl_vendor, 8, 115);  // Fix 5: +2px gap
   lv_label_set_long_mode(lbl_vendor, LV_LABEL_LONG_DOT);
@@ -280,13 +281,13 @@ void buildUI() {
 
   lv_obj_t *lbl_temp_cap = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_temp_cap, T(STR_LBL_TEMP));
-  lv_obj_set_style_text_color(lbl_temp_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_temp_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_temp_cap, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_pos(lbl_temp_cap, 248, 98);  // Fix 5: more right
 
   lbl_temp = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_temp, "-");
-  lv_obj_set_style_text_color(lbl_temp, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_temp, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_temp, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_pos(lbl_temp, 248, 115);  // Fix 5: more right
 
@@ -295,9 +296,9 @@ void buildUI() {
   lv_obj_set_size(btn_more, 84, 34);
   lv_obj_set_pos(btn_more, 388, 100);
   lv_obj_set_style_bg_color(btn_more, lv_color_hex(0x0d1f38), 0);
-  lv_obj_set_style_bg_color(btn_more, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_more, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_border_width(btn_more, 1, 0);
-  lv_obj_set_style_border_color(btn_more, lv_color_hex(0x28d49a), 0);  // teal border
+  lv_obj_set_style_border_color(btn_more, tc(TH_ACCENT), 0);  // teal border
   lv_obj_set_style_radius(btn_more, 6, 0);
   lv_obj_set_style_shadow_width(btn_more, 0, 0);
   lv_obj_add_event_cb(btn_more, [](lv_event_t *e){ logSD("BTN: Main -> MoreInfo"); showMoreInfoScreen(); }, LV_EVENT_CLICKED, NULL);
@@ -305,7 +306,7 @@ void buildUI() {
   char more_buf[24]; strncpy(more_buf, T(STR_BTN_MORE_INFO), sizeof(more_buf)-1);
   more_buf[sizeof(more_buf)-1] = '\0';
   lv_label_set_text(lbl_more, more_buf);
-  lv_obj_set_style_text_color(lbl_more, lv_color_hex(0x28d49a), 0);  // teal text
+  lv_obj_set_style_text_color(lbl_more, tc(TH_ACCENT), 0);  // teal text
   lv_obj_set_style_text_font(lbl_more, &lv_font_montserrat_ext_12, 0);
   lv_obj_center(lbl_more);
 
@@ -329,7 +330,7 @@ void buildUI() {
     strncpy(lu_cap_buf, T(STR_LBL_LAST_USED), sizeof(lu_cap_buf)-1);
   lu_cap_buf[sizeof(lu_cap_buf)-1] = '\0';
   lv_label_set_text(lbl_lu_cap, lu_cap_buf);
-  lv_obj_set_style_text_color(lbl_lu_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_lu_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_lu_cap, &lv_font_montserrat_ext_14, 0);  // Fix 5
   lv_obj_set_pos(lbl_lu_cap, 8, 142);
 
@@ -343,7 +344,7 @@ void buildUI() {
 
   lv_obj_t *lbl_ld_cap = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_ld_cap, T(STR_LBL_LAST_DRIED));
-  lv_obj_set_style_text_color(lbl_ld_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_ld_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_ld_cap, &lv_font_montserrat_ext_14, 0);  // Fix 5
   lv_obj_set_pos(lbl_ld_cap, 244, 142);
 
@@ -358,7 +359,7 @@ void buildUI() {
   // Ampel-Symbol (WARNING) rechts vom Datum, standardmaessig versteckt
   lbl_dried_sym = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_dried_sym, LV_SYMBOL_WARNING);
-  lv_obj_set_style_text_color(lbl_dried_sym, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_dried_sym, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_dried_sym, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_pos(lbl_dried_sym, 456, 158);
   lv_obj_add_flag(lbl_dried_sym, LV_OBJ_FLAG_HIDDEN);
@@ -385,7 +386,7 @@ void buildUI() {
   lv_obj_t *sep2 = lv_obj_create(lv_scr_act());
   lv_obj_set_size(sep2, 480, 1);
   lv_obj_set_pos(sep2, 0, 184);
-  lv_obj_set_style_bg_color(sep2, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(sep2, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(sep2, 0, 0);
   lv_obj_set_style_radius(sep2, 0, 0);
   lv_obj_set_style_pad_all(sep2, 0, 0);
@@ -400,21 +401,21 @@ void buildUI() {
   // not translated, and STR_LBL_SPOOLMAN is identical in both languages.
   lbl_sm_cap = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_sm_cap, backendIsFilaMan() ? "FilaMan:" : "Spoolman:");
-  lv_obj_set_style_text_color(lbl_sm_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_sm_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_sm_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(lbl_sm_cap, 8, 188);
 
   // Spoolman filament remaining — BIG
   lbl_spoolman_weight = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_spoolman_weight, wifi_ok ? "..." : T(STR_NO_WIFI));
-  lv_obj_set_style_text_color(lbl_spoolman_weight, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_spoolman_weight, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_spoolman_weight, &lv_font_montserrat_ext_20, 0);
   lv_obj_set_pos(lbl_spoolman_weight, 8, 204);
 
   // Percent — Fix 3: right of weight, same row
   lbl_spoolman_pct = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_spoolman_pct, "");
-  lv_obj_set_style_text_color(lbl_spoolman_pct, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_spoolman_pct, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_spoolman_pct, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_pos(lbl_spoolman_pct, 88, 208);  // right of weight, vertically centered
 
@@ -422,7 +423,7 @@ void buildUI() {
   lv_obj_t *bar_bg = lv_obj_create(lv_scr_act());
   lv_obj_set_size(bar_bg, 190, 8);
   lv_obj_set_pos(bar_bg, 8, 244);
-  lv_obj_set_style_bg_color(bar_bg, lv_color_hex(0x0a1828), 0);
+  lv_obj_set_style_bg_color(bar_bg, tc(TH_SURFACE), 0);
   lv_obj_set_style_border_width(bar_bg, 0, 0);
   lv_obj_set_style_radius(bar_bg, 4, 0);
   lv_obj_set_style_pad_all(bar_bg, 0, 0);
@@ -431,7 +432,7 @@ void buildUI() {
   lv_obj_t *bar_fill = lv_obj_create(bar_bg);
   lv_obj_set_size(bar_fill, 0, 8);
   lv_obj_set_pos(bar_fill, 0, 0);
-  lv_obj_set_style_bg_color(bar_fill, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_bg_color(bar_fill, tc(TH_ACCENT), 0);
   lv_obj_set_style_border_width(bar_fill, 0, 0);
   lv_obj_set_style_radius(bar_fill, 4, 0);
   lv_obj_set_style_pad_all(bar_fill, 0, 0);
@@ -452,27 +453,27 @@ void buildUI() {
   char sc_cap_buf[24]; strncpy(sc_cap_buf, T(STR_LBL_SCALE_SPOOL_CAP), sizeof(sc_cap_buf)-1);
   sc_cap_buf[sizeof(sc_cap_buf)-1] = '\0';
   lv_label_set_text(lbl_sc_cap, sc_cap_buf);
-  lv_obj_set_style_text_color(lbl_sc_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_sc_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_sc_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(lbl_sc_cap, 218, 188);
 
   // Scale filament netto — BIG
   lbl_scale_weight = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_scale_weight, scale_ready ? "0 g" : "---");
-  lv_obj_set_style_text_color(lbl_scale_weight, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_scale_weight, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_scale_weight, &lv_font_montserrat_ext_20, 0);
   lv_obj_set_pos(lbl_scale_weight, 218, 204);
 
   // SM diff caption + value — both diffs stacked on right side (Fix 3)
   lv_obj_t *lbl_diff_cap = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_diff_cap, "Diff:");
-  lv_obj_set_style_text_color(lbl_diff_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_diff_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_diff_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(lbl_diff_cap, 362, 188);
 
   lbl_raw_info = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_raw_info, "");
-  lv_obj_set_style_text_color(lbl_raw_info, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_raw_info, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_raw_info, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_pos(lbl_raw_info, 362, 204);  // Fix 3: right column
 
@@ -481,7 +482,7 @@ void buildUI() {
   char live_cap_buf[16]; strncpy(live_cap_buf, T(STR_LBL_TOTAL_CAP), sizeof(live_cap_buf)-1);
   live_cap_buf[sizeof(live_cap_buf)-1] = '\0';
   lv_label_set_text(lbl_live_cap, live_cap_buf);
-  lv_obj_set_style_text_color(lbl_live_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_live_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_live_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(lbl_live_cap, 218, 228);
 
@@ -496,13 +497,13 @@ void buildUI() {
   char bag_cap_buf[16]; strncpy(bag_cap_buf, T(STR_LBL_WO_BAG_CAP), sizeof(bag_cap_buf)-1);
   bag_cap_buf[sizeof(bag_cap_buf)-1] = '\0';
   lv_label_set_text(lbl_bag_cap, bag_cap_buf);
-  lv_obj_set_style_text_color(lbl_bag_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_bag_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_bag_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(lbl_bag_cap, 218, 246);
 
   lv_obj_t *lbl_bag_diff = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_bag_diff, "");
-  lv_obj_set_style_text_color(lbl_bag_diff, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_bag_diff, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_bag_diff, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_pos(lbl_bag_diff, 286, 244);
   lbl_keys = lbl_bag_diff;
@@ -510,7 +511,7 @@ void buildUI() {
   // Fix 3+4: bag SM diff — stacked below Waage-Spule diff, with "g"
   lbl_bag_sm_diff = lv_label_create(lv_scr_act());
   lv_label_set_text(lbl_bag_sm_diff, "");
-  lv_obj_set_style_text_color(lbl_bag_sm_diff, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_bag_sm_diff, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_bag_sm_diff, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_pos(lbl_bag_sm_diff, 362, 244);  // same x as Waage-Spule diff, below
 
@@ -550,12 +551,12 @@ void buildUI() {
   // Icon top, text bottom — both centered
   lv_obj_t *lbl_tare_icon = lv_label_create(btn_tare);
   lv_label_set_text(lbl_tare_icon, LV_SYMBOL_REFRESH);
-  lv_obj_set_style_text_color(lbl_tare_icon, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_tare_icon, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_tare_icon, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(lbl_tare_icon, LV_ALIGN_CENTER, 0, -10);
   lv_obj_t *lbl_tare_txt = lv_label_create(btn_tare);
   lv_label_set_text(lbl_tare_txt, "TARE");
-  lv_obj_set_style_text_color(lbl_tare_txt, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_tare_txt, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_tare_txt, &lv_font_montserrat_ext_10, 0);
   lv_obj_align(lbl_tare_txt, LV_ALIGN_CENTER, 0, 12);
 
@@ -563,7 +564,7 @@ void buildUI() {
   lv_obj_t *sep3 = lv_obj_create(lv_scr_act());
   lv_obj_set_size(sep3, 480, 1);
   lv_obj_set_pos(sep3, 0, 264);
-  lv_obj_set_style_bg_color(sep3, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(sep3, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(sep3, 0, 0);
   lv_obj_set_style_radius(sep3, 0, 0);
   lv_obj_set_style_pad_all(sep3, 0, 0);
@@ -574,7 +575,7 @@ void buildUI() {
   lv_obj_t *btn_bar = lv_obj_create(lv_scr_act());
   lv_obj_set_size(btn_bar, 480, 55);
   lv_obj_set_pos(btn_bar, 0, 265);
-  lv_obj_set_style_bg_color(btn_bar, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(btn_bar, tc(TH_BG), 0);
   lv_obj_set_style_border_width(btn_bar, 0, 0);
   lv_obj_set_style_radius(btn_bar, 0, 0);
   lv_obj_set_style_pad_all(btn_bar, 0, 0);
@@ -584,10 +585,10 @@ void buildUI() {
   btn_weight_main = lv_btn_create(btn_bar);
   lv_obj_set_size(btn_weight_main, 204, 40);
   lv_obj_set_pos(btn_weight_main, 6, 8);
-  lv_obj_set_style_bg_color(btn_weight_main, lv_color_hex(0x1a3020), 0);
-  lv_obj_set_style_bg_color(btn_weight_main, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_weight_main, tc(TH_OK_BG), 0);
+  lv_obj_set_style_bg_color(btn_weight_main, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
   lv_obj_set_style_border_width(btn_weight_main, 1, 0);
-  lv_obj_set_style_border_color(btn_weight_main, lv_color_hex(0x2a5030), 0);
+  lv_obj_set_style_border_color(btn_weight_main, tc(TH_SUCCESS_BG), 0);
   lv_obj_set_style_radius(btn_weight_main, 8, 0);
   lv_obj_set_style_shadow_width(btn_weight_main, 0, 0);
   lv_obj_add_event_cb(btn_weight_main, [](lv_event_t *e) {
@@ -606,7 +607,7 @@ void buildUI() {
     }
     lv_label_set_text(lbl_wm, wmbuf);
   }
-  lv_obj_set_style_text_color(lbl_wm, g_auto_weight ? lv_color_hex(0x28d49a) : lv_color_hex(0x40c080), 0);
+  lv_obj_set_style_text_color(lbl_wm, g_auto_weight ? tc(TH_ACCENT) : tc(TH_SUCCESS_TEXT), 0);
   lv_obj_set_style_text_font(lbl_wm, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_wm, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_wm, LV_ALIGN_CENTER, 0, 0);
@@ -687,16 +688,16 @@ void buildUI() {
   lv_obj_t *btn_menu = lv_btn_create(btn_bar);
   lv_obj_set_size(btn_menu, 44, 40);
   lv_obj_set_pos(btn_menu, 429, 8);
-  lv_obj_set_style_bg_color(btn_menu, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_menu, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_menu, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_menu, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_border_width(btn_menu, 1, 0);
-  lv_obj_set_style_border_color(btn_menu, lv_color_hex(0x1a2840), 0);
+  lv_obj_set_style_border_color(btn_menu, tc(TH_SURFACE_3), 0);
   lv_obj_set_style_radius(btn_menu, 8, 0);
   lv_obj_set_style_shadow_width(btn_menu, 0, 0);
   lv_obj_add_event_cb(btn_menu, [](lv_event_t *e){ logSD("UI: Button -> Burger Menu"); showSettingsScreen(); }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_menu = lv_label_create(btn_menu);
   lv_label_set_text(lbl_menu, LV_SYMBOL_LIST);
-  lv_obj_set_style_text_color(lbl_menu, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_menu, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_menu, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_menu);
 

--- a/src/ui/more_info_screen.cpp
+++ b/src/ui/more_info_screen.cpp
@@ -18,6 +18,7 @@
 #include "lang.h"
 #include "tag_display.h"
 #include "ui_common.h"
+#include "theme.h"
 
 
 void showLocationPicker();
@@ -77,7 +78,7 @@ void showLocationPicker() {
   scr_location_picker = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr_location_picker, 480, 320);
   lv_obj_set_pos(scr_location_picker, 0, 0);
-  lv_obj_set_style_bg_color(scr_location_picker, lv_color_hex(0x000000), 0);
+  lv_obj_set_style_bg_color(scr_location_picker, tc(TH_BLACK), 0);
   lv_obj_set_style_bg_opa(scr_location_picker, LV_OPA_70, 0);
   lv_obj_set_style_border_width(scr_location_picker, 0, 0);
   lv_obj_set_style_radius(scr_location_picker, 0, 0);
@@ -89,7 +90,7 @@ void showLocationPicker() {
   lv_obj_set_size(box, 400, 280);
   lv_obj_align(box, LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_bg_color(box, lv_color_hex(0x0b1525), 0);
-  lv_obj_set_style_border_color(box, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_border_color(box, tc(TH_ACCENT), 0);
   lv_obj_set_style_border_width(box, 1, 0);
   lv_obj_set_style_radius(box, 10, 0);
   lv_obj_set_style_pad_all(box, 0, 0);
@@ -99,7 +100,7 @@ void showLocationPicker() {
   lv_obj_t *hdr = lv_obj_create(box);
   lv_obj_set_size(hdr, 400, 44);
   lv_obj_set_pos(hdr, 0, 0);
-  lv_obj_set_style_bg_color(hdr, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(hdr, tc(TH_BG), 0);
   lv_obj_set_style_border_width(hdr, 0, 0);
   lv_obj_set_style_radius(hdr, 0, 0);
   lv_obj_set_style_pad_all(hdr, 0, 0);
@@ -109,15 +110,15 @@ void showLocationPicker() {
   char title_buf[48];
   strncpy(title_buf, T(STR_LOCATION_TITLE), sizeof(title_buf)-1);
   lv_label_set_text(lbl_title, title_buf);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(lbl_title, LV_ALIGN_CENTER, 0, 0);
 
   lv_obj_t *btn_x = lv_btn_create(hdr);
   lv_obj_set_size(btn_x, 40, 40);
   lv_obj_align(btn_x, LV_ALIGN_RIGHT_MID, -4, 0);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_border_width(btn_x, 1, 0);
   lv_obj_set_style_border_color(btn_x, lv_color_hex(0x601010), 0);
   lv_obj_set_style_radius(btn_x, 8, 0);
@@ -129,7 +130,7 @@ void showLocationPicker() {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_x = lv_label_create(btn_x);
   lv_label_set_text(lbl_x, LV_SYMBOL_CLOSE);
-  lv_obj_set_style_text_color(lbl_x, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_x, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_x, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_x);
 
@@ -138,7 +139,7 @@ void showLocationPicker() {
   char status_buf[48];
   strncpy(status_buf, T(STR_LOCATION_LOADING), sizeof(status_buf)-1);
   lv_label_set_text(lbl_status, status_buf);
-  lv_obj_set_style_text_color(lbl_status, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_status, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_status, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(lbl_status, LV_ALIGN_CENTER, 0, 10);
 
@@ -214,7 +215,7 @@ void fetchAndFillLocationList() {
   lv_obj_t *btn_none = lv_btn_create(list);
   lv_obj_set_size(btn_none, 370, 44);
   lv_obj_set_style_bg_color(btn_none, lv_color_hex(0x0d2040), 0);
-  lv_obj_set_style_bg_color(btn_none, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_none, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_border_color(btn_none, lv_color_hex(0x0f1e30), 0);
   lv_obj_set_style_border_width(btn_none, 1, 0);
   lv_obj_set_style_radius(btn_none, 6, 0);
@@ -251,8 +252,8 @@ void fetchAndFillLocationList() {
     lv_obj_set_size(row, 370, 44);
     bool is_current = (strlen(sm_location_name) > 0 && strcmp(loc_name, sm_location_name) == 0);
     lv_obj_set_style_bg_color(row, is_current ? lv_color_hex(0x0d3020) : lv_color_hex(0x0d2040), 0);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
-    lv_obj_set_style_border_color(row, is_current ? lv_color_hex(0x28d49a) : lv_color_hex(0x0f1e30), 0);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE_2), LV_STATE_PRESSED);
+    lv_obj_set_style_border_color(row, is_current ? tc(TH_ACCENT) : lv_color_hex(0x0f1e30), 0);
     lv_obj_set_style_border_width(row, 1, 0);
     lv_obj_set_style_radius(row, 6, 0);
     lv_obj_set_style_shadow_width(row, 0, 0);
@@ -260,7 +261,7 @@ void fetchAndFillLocationList() {
 
     lv_obj_t *lbl_row = lv_label_create(row);
     lv_label_set_text(lbl_row, loc_name);
-    lv_obj_set_style_text_color(lbl_row, is_current ? lv_color_hex(0x28d49a) : lv_color_hex(0xf0f0f0), 0);
+    lv_obj_set_style_text_color(lbl_row, is_current ? tc(TH_ACCENT) : lv_color_hex(0xf0f0f0), 0);
     lv_obj_set_style_text_font(lbl_row, &lv_font_montserrat_ext_16, 0);
     lv_obj_center(lbl_row);
 
@@ -290,13 +291,13 @@ void fetchAndFillLocationList() {
     lv_obj_set_style_bg_color(limit_row, lv_color_hex(0x1a0808), 0);
     lv_obj_set_style_radius(limit_row, 6, 0);
     lv_obj_set_style_border_width(limit_row, 1, 0);
-    lv_obj_set_style_border_color(limit_row, lv_color_hex(0x3a1010), 0);
+    lv_obj_set_style_border_color(limit_row, tc(TH_DANGER_BG), 0);
     lv_obj_set_style_pad_all(limit_row, 0, 0);
     lv_obj_clear_flag(limit_row, LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_CLICKABLE);
     lv_obj_t *limit_lbl = lv_label_create(limit_row);
     char limit_buf[64]; strncpy(limit_buf, T(STR_LOCATION_LIMIT_HIT), sizeof(limit_buf)-1);
     lv_label_set_text(limit_lbl, limit_buf);
-    lv_obj_set_style_text_color(limit_lbl, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(limit_lbl, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(limit_lbl, &lv_font_montserrat_ext_12, 0);
     lv_obj_set_style_text_align(limit_lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_label_set_long_mode(limit_lbl, LV_LABEL_LONG_WRAP);
@@ -320,7 +321,7 @@ void fetchAndFillLocationList() {
   lv_obj_t *hint_lbl = lv_label_create(hint_row);
   char hint_buf[64]; strncpy(hint_buf, T(STR_LOCATION_HINT_EMPTY), sizeof(hint_buf)-1);
   lv_label_set_text(hint_lbl, hint_buf);
-  lv_obj_set_style_text_color(hint_lbl, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(hint_lbl, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(hint_lbl, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(hint_lbl, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(hint_lbl, LV_LABEL_LONG_WRAP);
@@ -334,7 +335,7 @@ void buildMoreInfoScreen() {
   scr_more_info = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr_more_info, 480, 320);
   lv_obj_set_pos(scr_more_info, 0, 0);
-  lv_obj_set_style_bg_color(scr_more_info, lv_color_hex(0x000000), 0);
+  lv_obj_set_style_bg_color(scr_more_info, tc(TH_BLACK), 0);
   lv_obj_set_style_bg_opa(scr_more_info, LV_OPA_50, 0);
   lv_obj_set_style_border_width(scr_more_info, 0, 0);
   lv_obj_set_style_radius(scr_more_info, 0, 0);
@@ -346,7 +347,7 @@ void buildMoreInfoScreen() {
   lv_obj_set_size(box, 464, 300);
   lv_obj_set_pos(box, 8, 10);
   lv_obj_set_style_bg_color(box, lv_color_hex(0x0b1525), 0);
-  lv_obj_set_style_border_color(box, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_border_color(box, tc(TH_ACCENT), 0);
   lv_obj_set_style_border_width(box, 1, 0);
   lv_obj_set_style_radius(box, 10, 0);
   lv_obj_set_style_pad_all(box, 0, 0);
@@ -356,7 +357,7 @@ void buildMoreInfoScreen() {
   lv_obj_t *hdr = lv_obj_create(box);
   lv_obj_set_size(hdr, 464, 52);
   lv_obj_set_pos(hdr, 0, 0);
-  lv_obj_set_style_bg_color(hdr, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(hdr, tc(TH_BG), 0);
   lv_obj_set_style_border_width(hdr, 0, 0);
   lv_obj_set_style_radius(hdr, 0, 0);
   lv_obj_set_style_pad_all(hdr, 0, 0);
@@ -365,7 +366,7 @@ void buildMoreInfoScreen() {
   // Title — Fix 12: always "More info filament" in both languages
   lv_obj_t *lbl_title = lv_label_create(hdr);
   lv_label_set_text(lbl_title, "Filament");
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(lbl_title, LV_ALIGN_CENTER, 0, 0);
 
@@ -373,8 +374,8 @@ void buildMoreInfoScreen() {
   lv_obj_t *btn_x = lv_btn_create(hdr);
   lv_obj_set_size(btn_x, 44, 44);
   lv_obj_align(btn_x, LV_ALIGN_RIGHT_MID, -4, 0);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_border_width(btn_x, 1, 0);
   lv_obj_set_style_border_color(btn_x, lv_color_hex(0x601010), 0);
   lv_obj_set_style_radius(btn_x, 8, 0);
@@ -384,7 +385,7 @@ void buildMoreInfoScreen() {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_x = lv_label_create(btn_x);
   lv_label_set_text(lbl_x, LV_SYMBOL_CLOSE);
-  lv_obj_set_style_text_color(lbl_x, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_x, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_x, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_x);
 
@@ -392,7 +393,7 @@ void buildMoreInfoScreen() {
   lv_obj_t *hdiv = lv_obj_create(box);
   lv_obj_set_size(hdiv, 464, 1);
   lv_obj_set_pos(hdiv, 0, 52);
-  lv_obj_set_style_bg_color(hdiv, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(hdiv, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(hdiv, 0, 0);
   lv_obj_set_style_radius(hdiv, 0, 0);
   lv_obj_set_style_pad_all(hdiv, 0, 0);
@@ -401,7 +402,7 @@ void buildMoreInfoScreen() {
   // Cap: ID
   lv_obj_t *mi_id_cap = lv_label_create(box);
   lv_label_set_text(mi_id_cap, "ID");
-  lv_obj_set_style_text_color(mi_id_cap, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(mi_id_cap, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(mi_id_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(mi_id_cap, 60, 55);
 
@@ -409,7 +410,7 @@ void buildMoreInfoScreen() {
   lv_obj_set_size(swatch, 42, 42);
   lv_obj_set_pos(swatch, 10, 60);
   lv_obj_set_style_radius(swatch, 6, 0);
-  lv_obj_set_style_border_color(swatch, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_border_color(swatch, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_border_width(swatch, 1, 0);
   lv_obj_set_style_pad_all(swatch, 0, 0);
   lv_obj_clear_flag(swatch, LV_OBJ_FLAG_SCROLLABLE);
@@ -426,14 +427,14 @@ void buildMoreInfoScreen() {
   else strncpy(id_buf, "?", sizeof(id_buf)-1);
   lv_label_set_text(lbl_id, id_buf);
   lv_obj_set_style_text_color(lbl_id,
-    (sm_found && sm_id > 0) ? lv_color_hex(0x28d49a) : lv_color_hex(0xf0b838), 0);
+    (sm_found && sm_id > 0) ? tc(TH_ACCENT) : tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_id, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_pos(lbl_id, 60, 70);
 
   // Cap: Material
   lv_obj_t *mi_mat_cap = lv_label_create(box);
   lv_label_set_text(mi_mat_cap, "Material");
-  lv_obj_set_style_text_color(mi_mat_cap, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(mi_mat_cap, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(mi_mat_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(mi_mat_cap, 98, 55);
 
@@ -451,7 +452,7 @@ void buildMoreInfoScreen() {
   // Cap: Filament
   lv_obj_t *mi_fn_cap = lv_label_create(box);
   lv_label_set_text(mi_fn_cap, "Filament");
-  lv_obj_set_style_text_color(mi_fn_cap, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(mi_fn_cap, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(mi_fn_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(mi_fn_cap, 264, 55);
 
@@ -488,7 +489,7 @@ void buildMoreInfoScreen() {
   hex_cap[sizeof(hex_cap)-1] = '\0';
   lv_obj_t *c1 = lv_label_create(box);
   lv_label_set_text(c1, hex_cap);
-  lv_obj_set_style_text_color(c1, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(c1, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(c1, &lv_font_montserrat_ext_14, 0);  // Fix 6: 12→14
   lv_obj_set_pos(c1, CA, 114);
   lv_obj_t *v1 = lv_label_create(box);
@@ -504,7 +505,7 @@ void buildMoreInfoScreen() {
   prod_cap[sizeof(prod_cap)-1] = '\0';
   lv_obj_t *c2 = lv_label_create(box);
   lv_label_set_text(c2, prod_cap);
-  lv_obj_set_style_text_color(c2, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(c2, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(c2, &lv_font_montserrat_ext_14, 0);  // Fix 6
   lv_obj_set_pos(c2, CB, 114);
   lv_obj_t *v2 = lv_label_create(box);
@@ -518,12 +519,12 @@ void buildMoreInfoScreen() {
   art_cap[sizeof(art_cap)-1] = '\0';
   lv_obj_t *c3 = lv_label_create(box);
   lv_label_set_text(c3, art_cap);
-  lv_obj_set_style_text_color(c3, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(c3, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(c3, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_pos(c3, CA, 158);
   lv_obj_t *v3 = lv_label_create(box);
   lv_label_set_text(v3, strlen(sm_article_nr) > 0 ? sm_article_nr : "-");
-  lv_obj_set_style_text_color(v3, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(v3, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(v3, &lv_font_montserrat_ext_18, 0);
   lv_obj_set_pos(v3, CA, 158 + VF);
 
@@ -532,7 +533,7 @@ void buildMoreInfoScreen() {
   sw_cap[sizeof(sw_cap)-1] = '\0';
   lv_obj_t *c4 = lv_label_create(box);
   lv_label_set_text(c4, sw_cap);
-  lv_obj_set_style_text_color(c4, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(c4, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(c4, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_pos(c4, CB, 158);
   lv_obj_t *v4 = lv_label_create(box);
@@ -540,7 +541,7 @@ void buildMoreInfoScreen() {
   if (sm_spool_weight > 0) snprintf(sw_buf, sizeof(sw_buf), "%.0f g", sm_spool_weight);
   else strncpy(sw_buf, "-", sizeof(sw_buf)-1);
   lv_label_set_text(v4, sw_buf);
-  lv_obj_set_style_text_color(v4, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(v4, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(v4, &lv_font_montserrat_ext_18, 0);
   lv_obj_set_pos(v4, CB, 158 + VF);
 
@@ -556,12 +557,12 @@ void buildMoreInfoScreen() {
   // Fix 7: UID left + Spoolman ID right — shifted down (y=206)
   lv_obj_t *c_uid = lv_label_create(box);
   lv_label_set_text(c_uid, "UID");
-  lv_obj_set_style_text_color(c_uid, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(c_uid, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(c_uid, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_pos(c_uid, 10, 206);
   lv_obj_t *v_uid = lv_label_create(box);
   lv_label_set_text(v_uid, strlen(g_tag.uid_str) > 0 ? g_tag.uid_str : "-");
-  lv_obj_set_style_text_color(v_uid, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(v_uid, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(v_uid, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_pos(v_uid, 10, 206 + 13);
 
@@ -570,8 +571,8 @@ void buildMoreInfoScreen() {
   lv_obj_set_size(btn_loc, 220, 46);
   lv_obj_set_pos(btn_loc, CB - 10, 204);
   lv_obj_set_style_bg_color(btn_loc, lv_color_hex(0x0d2040), 0);
-  lv_obj_set_style_bg_color(btn_loc, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
-  lv_obj_set_style_border_color(btn_loc, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(btn_loc, tc(TH_SURFACE_2), LV_STATE_PRESSED);
+  lv_obj_set_style_border_color(btn_loc, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(btn_loc, 1, 0);
   lv_obj_set_style_radius(btn_loc, 8, 0);
   lv_obj_set_style_shadow_width(btn_loc, 0, 0);
@@ -581,7 +582,7 @@ void buildMoreInfoScreen() {
   char loc_cap_buf[32];
   strncpy(loc_cap_buf, T(STR_BTN_LOCATION), sizeof(loc_cap_buf)-1);
   lv_label_set_text(btn_loc_cap, loc_cap_buf);
-  lv_obj_set_style_text_color(btn_loc_cap, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(btn_loc_cap, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(btn_loc_cap, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(btn_loc_cap, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(btn_loc_cap, LV_ALIGN_CENTER, 0, -11);
@@ -591,7 +592,7 @@ void buildMoreInfoScreen() {
   strncpy(loc_val_buf, sm_location_name[0] ? sm_location_name : "-", sizeof(loc_val_buf)-1);
   loc_val_buf[sizeof(loc_val_buf)-1] = '\0';
   lv_label_set_text(btn_loc_val, loc_val_buf);
-  lv_obj_set_style_text_color(btn_loc_val, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(btn_loc_val, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(btn_loc_val, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(btn_loc_val, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_set_width(btn_loc_val, 204);
@@ -607,7 +608,7 @@ void buildMoreInfoScreen() {
   // Spoolman UUID — shifted down (y=246)
   lv_obj_t *c_uuid = lv_label_create(box);
   { char ub[32]; snprintf(ub, sizeof(ub), "%s UUID", backendName()); lv_label_set_text(c_uuid, ub); }
-  lv_obj_set_style_text_color(c_uuid, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(c_uuid, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(c_uuid, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_pos(c_uuid, 10, 248);
   lv_obj_t *v_uuid = lv_label_create(box);
@@ -624,8 +625,8 @@ void buildMoreInfoScreen() {
     lv_obj_t *btn_unlink = lv_btn_create(box);
     lv_obj_set_size(btn_unlink, 104, 34);
     lv_obj_set_pos(btn_unlink, 348, 258);
-    lv_obj_set_style_bg_color(btn_unlink, lv_color_hex(0x3a1010), 0);
-    lv_obj_set_style_bg_color(btn_unlink, lv_color_hex(0x602020), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_unlink, tc(TH_DANGER_BG), 0);
+    lv_obj_set_style_bg_color(btn_unlink, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_unlink, 8, 0);
     lv_obj_set_style_shadow_width(btn_unlink, 0, 0);
     lv_obj_set_style_border_width(btn_unlink, 1, 0);
@@ -635,7 +636,7 @@ void buildMoreInfoScreen() {
       lv_obj_t *pop = lv_obj_create(lv_scr_act());
       lv_obj_set_size(pop, 480, 320);
       lv_obj_set_pos(pop, 0, 0);
-      lv_obj_set_style_bg_color(pop, lv_color_hex(0x000000), 0);
+      lv_obj_set_style_bg_color(pop, tc(TH_BLACK), 0);
       lv_obj_set_style_bg_opa(pop, LV_OPA_80, 0);
       lv_obj_set_style_border_width(pop, 0, 0);
       lv_obj_set_style_radius(pop, 0, 0);
@@ -646,7 +647,7 @@ void buildMoreInfoScreen() {
       lv_obj_set_size(box2, 420, 210);
       lv_obj_align(box2, LV_ALIGN_CENTER, 0, 0);
       lv_obj_set_style_bg_color(box2, lv_color_hex(0x1a0808), 0);
-      lv_obj_set_style_border_color(box2, lv_color_hex(0x602020), 0);
+      lv_obj_set_style_border_color(box2, tc(TH_DANGER_PRESSED), 0);
       lv_obj_set_style_border_width(box2, 2, 0);
       lv_obj_set_style_radius(box2, 12, 0);
       lv_obj_set_style_pad_all(box2, 0, 0);
@@ -655,14 +656,14 @@ void buildMoreInfoScreen() {
       lv_obj_t *lbl_t = lv_label_create(box2);
       char buf_t[48]; strncpy(buf_t, T(STR_UNLINK_TITLE), sizeof(buf_t)-1);
       lv_label_set_text(lbl_t, buf_t);
-      lv_obj_set_style_text_color(lbl_t, lv_color_hex(0xff8080), 0);
+      lv_obj_set_style_text_color(lbl_t, tc(TH_DANGER_TEXT), 0);
       lv_obj_set_style_text_font(lbl_t, &lv_font_montserrat_ext_18, 0);
       lv_obj_align(lbl_t, LV_ALIGN_TOP_MID, 0, 16);
 
       lv_obj_t *lbl_m = lv_label_create(box2);
       char buf_m[192]; backendText(T(STR_UNLINK_MSG), buf_m, sizeof(buf_m));
       lv_label_set_text(lbl_m, buf_m);
-      lv_obj_set_style_text_color(lbl_m, lv_color_hex(0xc8d8f0), 0);
+      lv_obj_set_style_text_color(lbl_m, tc(TH_TEXT), 0);
       lv_obj_set_style_text_font(lbl_m, &lv_font_montserrat_ext_14, 0);
       lv_obj_set_style_text_align(lbl_m, LV_TEXT_ALIGN_CENTER, 0);
       lv_label_set_long_mode(lbl_m, LV_LABEL_LONG_WRAP);
@@ -673,19 +674,19 @@ void buildMoreInfoScreen() {
       lv_obj_t *btn_no = lv_btn_create(box2);
       lv_obj_set_size(btn_no, 170, 44);
       lv_obj_set_pos(btn_no, 12, 154);
-      lv_obj_set_style_bg_color(btn_no, lv_color_hex(0x0a1828), 0);
-      lv_obj_set_style_bg_color(btn_no, lv_color_hex(0x1a2840), LV_STATE_PRESSED);
+      lv_obj_set_style_bg_color(btn_no, tc(TH_SURFACE), 0);
+      lv_obj_set_style_bg_color(btn_no, tc(TH_SURFACE_3), LV_STATE_PRESSED);
       lv_obj_set_style_radius(btn_no, 8, 0);
       lv_obj_set_style_shadow_width(btn_no, 0, 0);
       lv_obj_set_style_border_width(btn_no, 1, 0);
-      lv_obj_set_style_border_color(btn_no, lv_color_hex(0x1a2840), 0);
+      lv_obj_set_style_border_color(btn_no, tc(TH_SURFACE_3), 0);
       lv_obj_add_event_cb(btn_no, [](lv_event_t *e) {
         lv_obj_del(lv_obj_get_parent(lv_obj_get_parent(lv_event_get_target(e))));
       }, LV_EVENT_CLICKED, NULL);
       lv_obj_t *lbl_no = lv_label_create(btn_no);
       char buf_no[32]; strncpy(buf_no, T(STR_CANCEL), sizeof(buf_no)-1);
       lv_label_set_text(lbl_no, buf_no);
-      lv_obj_set_style_text_color(lbl_no, lv_color_hex(0x4a6fa0), 0);
+      lv_obj_set_style_text_color(lbl_no, tc(TH_TEXT_MUTED), 0);
       lv_obj_set_style_text_font(lbl_no, &lv_font_montserrat_ext_14, 0);
       lv_obj_align(lbl_no, LV_ALIGN_CENTER, 0, 0);
 
@@ -693,12 +694,12 @@ void buildMoreInfoScreen() {
       lv_obj_t *btn_yes = lv_btn_create(box2);
       lv_obj_set_size(btn_yes, 220, 44);
       lv_obj_set_pos(btn_yes, 190, 154);
-      lv_obj_set_style_bg_color(btn_yes, lv_color_hex(0x3a1010), 0);
-      lv_obj_set_style_bg_color(btn_yes, lv_color_hex(0x602020), LV_STATE_PRESSED);
+      lv_obj_set_style_bg_color(btn_yes, tc(TH_DANGER_BG), 0);
+      lv_obj_set_style_bg_color(btn_yes, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
       lv_obj_set_style_radius(btn_yes, 8, 0);
       lv_obj_set_style_shadow_width(btn_yes, 0, 0);
       lv_obj_set_style_border_width(btn_yes, 1, 0);
-      lv_obj_set_style_border_color(btn_yes, lv_color_hex(0x602020), 0);
+      lv_obj_set_style_border_color(btn_yes, tc(TH_DANGER_PRESSED), 0);
       lv_obj_add_event_cb(btn_yes, [](lv_event_t *e) {
         // Close popup
         lv_obj_del(lv_obj_get_parent(lv_obj_get_parent(lv_event_get_target(e))));
@@ -714,7 +715,7 @@ void buildMoreInfoScreen() {
       lv_obj_t *lbl_yes = lv_label_create(btn_yes);
       char buf_yes[48]; strncpy(buf_yes, T(STR_UNLINK_CONFIRM), sizeof(buf_yes)-1);
       lv_label_set_text(lbl_yes, buf_yes);
-      lv_obj_set_style_text_color(lbl_yes, lv_color_hex(0xff8080), 0);
+      lv_obj_set_style_text_color(lbl_yes, tc(TH_DANGER_TEXT), 0);
       lv_obj_set_style_text_font(lbl_yes, &lv_font_montserrat_ext_14, 0);
       lv_obj_align(lbl_yes, LV_ALIGN_CENTER, 0, 0);
     }, LV_EVENT_CLICKED, NULL);
@@ -722,7 +723,7 @@ void buildMoreInfoScreen() {
     lv_obj_t *lbl_unlink = lv_label_create(btn_unlink);
     char buf_ul[16]; strncpy(buf_ul, T(STR_UNLINK_BTN), sizeof(buf_ul)-1);
     lv_label_set_text(lbl_unlink, buf_ul);
-    lv_obj_set_style_text_color(lbl_unlink, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_unlink, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(lbl_unlink, &lv_font_montserrat_ext_14, 0);
     lv_obj_align(lbl_unlink, LV_ALIGN_CENTER, 0, 0);
   }

--- a/src/ui/ota_browser.cpp
+++ b/src/ui/ota_browser.cpp
@@ -14,6 +14,7 @@
 #include "services/ota_web_server.h"
 #include "services/wifi_manager.h"
 #include "ui_common.h"
+#include "theme.h"
 
 // Which entry point brought the user here. Kept between show and build
 // because buildOtaBrowserScreen() is also reached through the generic
@@ -66,7 +67,7 @@ static lv_obj_t* addCredentialRow(lv_obj_t *parent, int y, const char *name,
 
   lv_obj_t *l = lv_label_create(parent);
   lv_label_set_text(l, name_buf);
-  lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(l, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_pos(l, 40, y);
 
@@ -77,7 +78,7 @@ static lv_obj_t* addCredentialRow(lv_obj_t *parent, int y, const char *name,
 
   lv_obj_t *v = lv_label_create(parent);
   lv_label_set_text(v, val_buf);
-  lv_obj_set_style_text_color(v, lv_color_hex(present ? 0x40c080 : 0xf0b838), 0);
+  lv_obj_set_style_text_color(v, lv_color_hex(present ? g_theme[TH_SUCCESS_TEXT] : g_theme[TH_WARNING]), 0);
   lv_obj_set_style_text_font(v, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(v, LV_ALIGN_TOP_RIGHT, -40, y);
   return v;
@@ -90,7 +91,7 @@ static void setCredentialRow(lv_obj_t *label, bool present) {
           sizeof(val_buf) - 1);
   val_buf[sizeof(val_buf) - 1] = '\0';
   lv_label_set_text(label, val_buf);
-  lv_obj_set_style_text_color(label, lv_color_hex(present ? 0x40c080 : 0xf0b838), 0);
+  lv_obj_set_style_text_color(label, lv_color_hex(present ? g_theme[TH_SUCCESS_TEXT] : g_theme[TH_WARNING]), 0);
 }
 
 // Remembers what the rows currently say. Rewriting a label invalidates it and
@@ -145,7 +146,7 @@ void buildOtaBrowserScreen() {
     // A plain title keeps the screen consistent with the other setup steps.
     lv_obj_t *lbl_title = lv_label_create(scr_ota_browser);
     lv_label_set_text(lbl_title, title_buf);
-    lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
     lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 12);
   } else {
@@ -168,7 +169,7 @@ void buildOtaBrowserScreen() {
     strncpy(err_buf, T(STR_OTA_NO_WIFI), sizeof(err_buf) - 1);
     err_buf[sizeof(err_buf) - 1] = '\0';
     lv_label_set_text(lbl_err, err_buf);
-    lv_obj_set_style_text_color(lbl_err, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_err, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(lbl_err, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(lbl_err, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl_err, LV_ALIGN_CENTER, 0, 0);
@@ -197,7 +198,7 @@ void buildOtaBrowserScreen() {
 
   lv_obj_t *lbl_hint = lv_label_create(scr_ota_browser);
   lv_label_set_text(lbl_hint, hint_buf);
-  lv_obj_set_style_text_color(lbl_hint, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_hint, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_hint, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_hint, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_hint, LV_LABEL_LONG_WRAP);
@@ -206,7 +207,7 @@ void buildOtaBrowserScreen() {
 
   lv_obj_t *lbl_ip = lv_label_create(scr_ota_browser);
   lv_label_set_text(lbl_ip, ip_buf);
-  lv_obj_set_style_text_color(lbl_ip, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_ip, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_ip, &lv_font_montserrat_ext_20, 0);
   lv_obj_align(lbl_ip, LV_ALIGN_TOP_MID, 0, showsCredentials() ? 108 : 80);
 
@@ -222,8 +223,8 @@ void buildOtaBrowserScreen() {
       lv_obj_t *btn_done = lv_btn_create(scr_ota_browser);
       lv_obj_set_size(btn_done, 200, 48);
       lv_obj_align(btn_done, LV_ALIGN_BOTTOM_MID, 0, -20);
-      lv_obj_set_style_bg_color(btn_done, lv_color_hex(0x1a3020), 0);
-      lv_obj_set_style_bg_color(btn_done, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+      lv_obj_set_style_bg_color(btn_done, tc(TH_OK_BG), 0);
+      lv_obj_set_style_bg_color(btn_done, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
       lv_obj_set_style_radius(btn_done, 8, 0);
       lv_obj_set_style_shadow_width(btn_done, 0, 0);
       lv_obj_set_style_border_width(btn_done, 0, 0);
@@ -238,7 +239,7 @@ void buildOtaBrowserScreen() {
       strncpy(done_buf, T(STR_BTN_FINISH), sizeof(done_buf) - 1);
       done_buf[sizeof(done_buf) - 1] = '\0';
       lv_label_set_text(lbl_done, done_buf);
-      lv_obj_set_style_text_color(lbl_done, lv_color_hex(0x40c080), 0);
+      lv_obj_set_style_text_color(lbl_done, tc(TH_SUCCESS_TEXT), 0);
       lv_obj_set_style_text_font(lbl_done, &lv_font_montserrat_ext_16, 0);
       lv_obj_center(lbl_done);
     }
@@ -255,7 +256,7 @@ void buildOtaBrowserScreen() {
   strncpy(file_buf, T(STR_OTA_FILE_HINT), sizeof(file_buf) - 1);
   file_buf[sizeof(file_buf) - 1] = '\0';
   lv_label_set_text(lbl_hint2, file_buf);
-  lv_obj_set_style_text_color(lbl_hint2, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(lbl_hint2, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(lbl_hint2, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(lbl_hint2, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_hint2, LV_ALIGN_TOP_MID, 0, 112);
@@ -267,7 +268,7 @@ void buildOtaBrowserScreen() {
   strncpy(wait_buf, T(STR_OTA_WAITING), sizeof(wait_buf) - 1);
   wait_buf[sizeof(wait_buf) - 1] = '\0';
   lv_label_set_text(lbl_ota_status, wait_buf);
-  lv_obj_set_style_text_color(lbl_ota_status, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_ota_status, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_ota_status, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_ota_status, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_ota_status, LV_ALIGN_CENTER, 0, 40);
@@ -275,8 +276,8 @@ void buildOtaBrowserScreen() {
   lv_obj_t *btn_stop = lv_btn_create(scr_ota_browser);
   lv_obj_set_size(btn_stop, 200, 48);
   lv_obj_align(btn_stop, LV_ALIGN_BOTTOM_MID, 0, -20);
-  lv_obj_set_style_bg_color(btn_stop, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_stop, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_stop, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_stop, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_stop, 8, 0);
   lv_obj_set_style_shadow_width(btn_stop, 0, 0);
   lv_obj_set_style_border_width(btn_stop, 0, 0);
@@ -290,7 +291,7 @@ void buildOtaBrowserScreen() {
   strncpy(stop_buf, T(STR_BTN_STOP_SERVER), sizeof(stop_buf) - 1);
   stop_buf[sizeof(stop_buf) - 1] = '\0';
   lv_label_set_text(lbl_stop, stop_buf);
-  lv_obj_set_style_text_color(lbl_stop, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_stop, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_stop, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_stop);
 }

--- a/src/ui/ota_github.cpp
+++ b/src/ui/ota_github.cpp
@@ -20,6 +20,7 @@
 #include "services/version_compare.h"
 #include "update_badges.h"
 #include "ui_common.h"
+#include "theme.h"
 
 
 
@@ -44,13 +45,13 @@ void doGithubOtaCheck() {
   if (!wifi_ok) {
     char buf[64]; strncpy(buf, T(STR_GH_OTA_NO_WIFI), sizeof(buf)-1); buf[sizeof(buf)-1]=0;
     lv_label_set_text(lbl_gh_status, buf);
-    lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_gh_status, tc(TH_DANGER_TEXT), 0);
     return;
   }
 
   char buf[64]; strncpy(buf, T(STR_GH_OTA_CHECKING), sizeof(buf)-1); buf[sizeof(buf)-1]=0;
   lv_label_set_text(lbl_gh_status, buf);
-  lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_gh_status, tc(TH_TEXT_MUTED), 0);
   lv_timer_handler();
 
   WiFiClientSecure client;
@@ -68,7 +69,7 @@ void doGithubOtaCheck() {
   if (code != 200) {
     snprintf(buf, sizeof(buf), "HTTP %d", code);
     lv_label_set_text(lbl_gh_status, buf);
-    lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_gh_status, tc(TH_DANGER_TEXT), 0);
     http.end();
     return;
   }
@@ -82,7 +83,7 @@ void doGithubOtaCheck() {
     doc.clear();
     if (deserializeJson(doc, payload)) {
       lv_label_set_text(lbl_gh_status, "JSON error");
-      lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0xff8080), 0);
+      lv_obj_set_style_text_color(lbl_gh_status, tc(TH_DANGER_TEXT), 0);
       return;
     }
     JsonArray arr = doc.as<JsonArray>();
@@ -96,7 +97,7 @@ void doGithubOtaCheck() {
     doc.clear();
     if (deserializeJson(doc, payload)) {
       lv_label_set_text(lbl_gh_status, "JSON error");
-      lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0xff8080), 0);
+      lv_obj_set_style_text_color(lbl_gh_status, tc(TH_DANGER_TEXT), 0);
       return;
     }
     tag = doc["tag_name"] | "";
@@ -104,7 +105,7 @@ void doGithubOtaCheck() {
 
   if (tag[0] == '\0') {
     lv_label_set_text(lbl_gh_status, "No release found");
-    lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_gh_status, tc(TH_DANGER_TEXT), 0);
     return;
   }
 
@@ -128,20 +129,20 @@ void doGithubOtaCheck() {
   if (remote <= cur) {
     char upd[48]; strncpy(upd, T(STR_GH_OTA_UP_TO_DATE), sizeof(upd)-1); upd[sizeof(upd)-1]=0;
     lv_label_set_text(lbl_gh_status, upd);
-    lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0x40c080), 0);
+    lv_obj_set_style_text_color(lbl_gh_status, tc(TH_SUCCESS_TEXT), 0);
   } else {
     char avail[64]; snprintf(avail, sizeof(avail), T(STR_GH_OTA_UPDATE_AVAIL), gh_latest_version);
     lv_label_set_text(lbl_gh_status, avail);
-    lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0xf0b838), 0);
+    lv_obj_set_style_text_color(lbl_gh_status, tc(TH_WARNING), 0);
     if (btn_gh_update) {
       lv_obj_clear_state(btn_gh_update, LV_STATE_DISABLED);
-      lv_obj_set_style_bg_color(btn_gh_update, lv_color_hex(0x1a3020), 0);
-      lv_obj_set_style_bg_color(btn_gh_update, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
-      lv_obj_set_style_border_color(btn_gh_update, lv_color_hex(0x28d49a), 0);
+      lv_obj_set_style_bg_color(btn_gh_update, tc(TH_OK_BG), 0);
+      lv_obj_set_style_bg_color(btn_gh_update, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
+      lv_obj_set_style_border_color(btn_gh_update, tc(TH_ACCENT), 0);
       if (lbl_gh_update_btn) {
         char ubtn[48]; strncpy(ubtn, T(STR_GH_OTA_UPDATE_BTN), sizeof(ubtn)-1); ubtn[sizeof(ubtn)-1]=0;
         lv_label_set_text(lbl_gh_update_btn, ubtn);
-        lv_obj_set_style_text_color(lbl_gh_update_btn, lv_color_hex(0x40c080), 0);
+        lv_obj_set_style_text_color(lbl_gh_update_btn, tc(TH_SUCCESS_TEXT), 0);
       }
     }
     update_available = true;
@@ -156,7 +157,7 @@ void doGithubOtaFlash(const char* version) {
   lv_obj_t *overlay = lv_obj_create(lv_layer_top());
   lv_obj_set_size(overlay, 480, 320);
   lv_obj_set_pos(overlay, 0, 0);
-  lv_obj_set_style_bg_color(overlay, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(overlay, tc(TH_BG), 0);
   lv_obj_set_style_bg_opa(overlay, LV_OPA_COVER, 0);
   lv_obj_set_style_border_width(overlay, 0, 0);
   lv_obj_set_style_pad_all(overlay, 0, 0);
@@ -165,21 +166,21 @@ void doGithubOtaFlash(const char* version) {
 
   lv_obj_t *ico = lv_label_create(overlay);
   lv_label_set_text(ico, LV_SYMBOL_DOWNLOAD);
-  lv_obj_set_style_text_color(ico, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(ico, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(ico, &lv_font_montserrat_ext_24, 0);
   lv_obj_align(ico, LV_ALIGN_CENTER, 0, -40);
 
   lv_obj_t *lbl_ov = lv_label_create(overlay);
   char buf_ov[64]; strncpy(buf_ov, T(STR_GH_OTA_FLASHING), sizeof(buf_ov)-1); buf_ov[sizeof(buf_ov)-1]=0;
   lv_label_set_text(lbl_ov, buf_ov);
-  lv_obj_set_style_text_color(lbl_ov, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_ov, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_ov, &lv_font_montserrat_ext_18, 0);
   lv_obj_set_style_text_align(lbl_ov, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_ov, LV_ALIGN_CENTER, 0, 0);
 
   lv_obj_t *lbl_hint = lv_label_create(overlay);
   lv_label_set_text(lbl_hint, "~30-60 sec");
-  lv_obj_set_style_text_color(lbl_hint, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_hint, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_hint, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_hint, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_hint, LV_ALIGN_CENTER, 0, 30);
@@ -189,7 +190,7 @@ void doGithubOtaFlash(const char* version) {
 
   char buf[64]; strncpy(buf, T(STR_GH_OTA_FLASHING), sizeof(buf)-1); buf[sizeof(buf)-1]=0;
   lv_label_set_text(lbl_gh_status, buf);
-  lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_gh_status, tc(TH_WARNING), 0);
   if (btn_gh_update) lv_obj_add_flag(btn_gh_update, LV_OBJ_FLAG_HIDDEN);
   lv_timer_handler();
 
@@ -213,7 +214,7 @@ void doGithubOtaFlash(const char* version) {
   if (code != 200) {
     snprintf(buf, sizeof(buf), "%s (HTTP %d)", T(STR_GH_OTA_FLASH_FAIL), code);
     lv_label_set_text(lbl_gh_status, buf);
-    lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_gh_status, tc(TH_DANGER_TEXT), 0);
     http.end();
     gh_flash_active = false;
     return;
@@ -224,7 +225,7 @@ void doGithubOtaFlash(const char* version) {
 
   if (!Update.begin(len > 0 ? len : UPDATE_SIZE_UNKNOWN)) {
     lv_label_set_text(lbl_gh_status, T(STR_GH_OTA_FLASH_FAIL));
-    lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_gh_status, tc(TH_DANGER_TEXT), 0);
     http.end();
     gh_flash_active = false;
     return;
@@ -247,7 +248,7 @@ void doGithubOtaFlash(const char* version) {
   if (Update.end(true) && !Update.hasError()) {
     char ok[64]; strncpy(ok, T(STR_GH_OTA_FLASH_OK), sizeof(ok)-1); ok[sizeof(ok)-1]=0;
     lv_label_set_text(lbl_gh_status, ok);
-    lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0x40c080), 0);
+    lv_obj_set_style_text_color(lbl_gh_status, tc(TH_SUCCESS_TEXT), 0);
     lv_timer_handler();
     delay(2000);
     ESP.restart();
@@ -255,7 +256,7 @@ void doGithubOtaFlash(const char* version) {
     gh_flash_active = false;
     char fail[64]; strncpy(fail, T(STR_GH_OTA_FLASH_FAIL), sizeof(fail)-1); fail[sizeof(fail)-1]=0;
     lv_label_set_text(lbl_gh_status, fail);
-    lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_gh_status, tc(TH_DANGER_TEXT), 0);
   }
 }
 
@@ -288,24 +289,24 @@ void buildOtaGithubScreen() {
   lv_obj_t *btn_check = lv_btn_create(scr_ota_github);
   lv_obj_set_size(btn_check, 280, 44);
   lv_obj_align(btn_check, LV_ALIGN_TOP_MID, 0, 56);
-  lv_obj_set_style_bg_color(btn_check, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn_check, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_check, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn_check, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_check, 8, 0);
   lv_obj_set_style_shadow_width(btn_check, 0, 0);
   lv_obj_set_style_border_width(btn_check, 1, 0);
-  lv_obj_set_style_border_color(btn_check, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_check, tc(TH_SURFACE_2), 0);
   lv_obj_add_event_cb(btn_check, [](lv_event_t *e){ doGithubOtaCheck(); }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_check = lv_label_create(btn_check);
   char buf_check[48]; strncpy(buf_check, T(STR_GH_OTA_CHECK_BTN), sizeof(buf_check)-1); buf_check[sizeof(buf_check)-1]=0;
   lv_label_set_text(lbl_check, buf_check);
-  lv_obj_set_style_text_color(lbl_check, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_check, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_check, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_check, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_check, LV_ALIGN_CENTER, 0, 0);
 
   lbl_gh_status = lv_label_create(scr_ota_github);
   lv_label_set_text(lbl_gh_status, "");
-  lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_gh_status, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_gh_status, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_gh_status, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_gh_status, LV_LABEL_LONG_WRAP);
@@ -314,7 +315,7 @@ void buildOtaGithubScreen() {
 
   lbl_gh_installed = lv_label_create(scr_ota_github);
   lv_label_set_text(lbl_gh_installed, "");
-  lv_obj_set_style_text_color(lbl_gh_installed, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_gh_installed, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_gh_installed, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_gh_installed, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_gh_installed, LV_ALIGN_TOP_MID, 0, 148);
@@ -322,7 +323,7 @@ void buildOtaGithubScreen() {
 
   lbl_gh_latest = lv_label_create(scr_ota_github);
   lv_label_set_text(lbl_gh_latest, "");
-  lv_obj_set_style_text_color(lbl_gh_latest, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_gh_latest, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_gh_latest, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_gh_latest, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_gh_latest, LV_ALIGN_TOP_MID, 0, 170);
@@ -334,12 +335,12 @@ void buildOtaGithubScreen() {
   lv_obj_t *btn_auto = lv_btn_create(scr_ota_github);
   lv_obj_set_size(btn_auto, 280, 36);
   lv_obj_align(btn_auto, LV_ALIGN_TOP_MID, 0, 200);
-  lv_obj_set_style_bg_color(btn_auto, g_upd_autocheck ? lv_color_hex(0x0a2040) : lv_color_hex(0x0a1020), 0);
-  lv_obj_set_style_bg_color(btn_auto, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_auto, g_upd_autocheck ? lv_color_hex(0x0a2040) : tc(TH_BG), 0);
+  lv_obj_set_style_bg_color(btn_auto, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_auto, 8, 0);
   lv_obj_set_style_shadow_width(btn_auto, 0, 0);
   lv_obj_set_style_border_width(btn_auto, 1, 0);
-  lv_obj_set_style_border_color(btn_auto, g_upd_autocheck ? lv_color_hex(0x28d49a) : lv_color_hex(0x1a2030), 0);
+  lv_obj_set_style_border_color(btn_auto, g_upd_autocheck ? tc(TH_ACCENT) : tc(TH_SURFACE_DARK), 0);
   lv_obj_add_event_cb(btn_auto, [](lv_event_t *e) {
     g_upd_autocheck = !g_upd_autocheck;
     prefsPutBool("upd_check", g_upd_autocheck);
@@ -363,7 +364,7 @@ void buildOtaGithubScreen() {
   snprintf(auto_buf, sizeof(auto_buf), "%s  %s", T(STR_GH_OTA_AUTOCHECK),
            g_upd_autocheck ? "[ ON ]" : "[ OFF ]");
   lv_label_set_text(lbl_auto, auto_buf);
-  lv_obj_set_style_text_color(lbl_auto, g_upd_autocheck ? lv_color_hex(0x28d49a) : lv_color_hex(0x2a3848), 0);
+  lv_obj_set_style_text_color(lbl_auto, g_upd_autocheck ? tc(TH_ACCENT) : lv_color_hex(0x2a3848), 0);
   lv_obj_set_style_text_font(lbl_auto, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(lbl_auto, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_auto, LV_ALIGN_CENTER, 0, 0);
@@ -371,12 +372,12 @@ void buildOtaGithubScreen() {
   lv_obj_t *btn_pre = lv_btn_create(scr_ota_github);
   lv_obj_set_size(btn_pre, 140, 48);
   lv_obj_align(btn_pre, LV_ALIGN_BOTTOM_LEFT, 12, -24);
-  lv_obj_set_style_bg_color(btn_pre, gh_prerelease ? lv_color_hex(0x0a2040) : lv_color_hex(0x0a1020), 0);
-  lv_obj_set_style_bg_color(btn_pre, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_pre, gh_prerelease ? lv_color_hex(0x0a2040) : tc(TH_BG), 0);
+  lv_obj_set_style_bg_color(btn_pre, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_pre, 8, 0);
   lv_obj_set_style_shadow_width(btn_pre, 0, 0);
   lv_obj_set_style_border_width(btn_pre, 1, 0);
-  lv_obj_set_style_border_color(btn_pre, gh_prerelease ? lv_color_hex(0x28d49a) : lv_color_hex(0x1a2030), 0);
+  lv_obj_set_style_border_color(btn_pre, gh_prerelease ? tc(TH_ACCENT) : tc(TH_SURFACE_DARK), 0);
   lv_obj_add_event_cb(btn_pre, [](lv_event_t *e) {
     gh_prerelease = !gh_prerelease;
     // Was written to the "spool" namespace while loadPrefs() reads from
@@ -391,7 +392,7 @@ void buildOtaGithubScreen() {
   char pre_buf[32];
   snprintf(pre_buf, sizeof(pre_buf), "%s\n%s", T(STR_GH_OTA_PRERELEASE), gh_prerelease ? "[ ON ]" : "[ OFF ]");
   lv_label_set_text(lbl_pre, pre_buf);
-  lv_obj_set_style_text_color(lbl_pre, gh_prerelease ? lv_color_hex(0x28d49a) : lv_color_hex(0x2a3848), 0);
+  lv_obj_set_style_text_color(lbl_pre, gh_prerelease ? tc(TH_ACCENT) : lv_color_hex(0x2a3848), 0);
   lv_obj_set_style_text_font(lbl_pre, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(lbl_pre, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_pre, LV_ALIGN_CENTER, 0, 0);
@@ -404,7 +405,7 @@ void buildOtaGithubScreen() {
   lv_obj_set_style_radius(btn_gh_update, 8, 0);
   lv_obj_set_style_shadow_width(btn_gh_update, 0, 0);
   lv_obj_set_style_border_width(btn_gh_update, 1, 0);
-  lv_obj_set_style_border_color(btn_gh_update, lv_color_hex(0x1a2030), 0);
+  lv_obj_set_style_border_color(btn_gh_update, tc(TH_SURFACE_DARK), 0);
   lv_obj_add_state(btn_gh_update, LV_STATE_DISABLED);
   lv_obj_add_event_cb(btn_gh_update, [](lv_event_t *e){
     doGithubOtaFlash(gh_latest_version);
@@ -420,15 +421,15 @@ void buildOtaGithubScreen() {
 
   if (update_available && gh_latest_version[0] != '\0') {
     lv_obj_clear_state(btn_gh_update, LV_STATE_DISABLED);
-    lv_obj_set_style_bg_color(btn_gh_update, lv_color_hex(0x1a3020), 0);
-    lv_obj_set_style_bg_color(btn_gh_update, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
-    lv_obj_set_style_border_color(btn_gh_update, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_bg_color(btn_gh_update, tc(TH_OK_BG), 0);
+    lv_obj_set_style_bg_color(btn_gh_update, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
+    lv_obj_set_style_border_color(btn_gh_update, tc(TH_ACCENT), 0);
     char ubtn2[48]; strncpy(ubtn2, T(STR_GH_OTA_UPDATE_BTN), sizeof(ubtn2)-1); ubtn2[sizeof(ubtn2)-1]=0;
     lv_label_set_text(lbl_gh_update_btn, ubtn2);
-    lv_obj_set_style_text_color(lbl_gh_update_btn, lv_color_hex(0x40c080), 0);
+    lv_obj_set_style_text_color(lbl_gh_update_btn, tc(TH_SUCCESS_TEXT), 0);
     char avail[64]; snprintf(avail, sizeof(avail), T(STR_GH_OTA_UPDATE_AVAIL), gh_latest_version);
     lv_label_set_text(lbl_gh_status, avail);
-    lv_obj_set_style_text_color(lbl_gh_status, lv_color_hex(0xf0b838), 0);
+    lv_obj_set_style_text_color(lbl_gh_status, tc(TH_WARNING), 0);
     char inst[48]; snprintf(inst, sizeof(inst), T(STR_GH_OTA_INSTALLED), FW_VERSION);
     lv_label_set_text(lbl_gh_installed, inst);
     lv_obj_clear_flag(lbl_gh_installed, LV_OBJ_FLAG_HIDDEN);

--- a/src/ui/ota_menu.cpp
+++ b/src/ui/ota_menu.cpp
@@ -13,6 +13,7 @@
 #include "services/ota_state.h"
 #include "ui_common.h"
 #include "update_badges.h"
+#include "theme.h"
 
 
 void showOtaGithubScreen();
@@ -38,26 +39,26 @@ void buildOtaScreen() {
   lv_obj_t *btn_browser = lv_btn_create(scr_ota);
   lv_obj_set_size(btn_browser, 456, 80);
   lv_obj_set_pos(btn_browser, 12, 58);
-  lv_obj_set_style_bg_color(btn_browser, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn_browser, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_browser, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn_browser, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_browser, 10, 0);
   lv_obj_set_style_shadow_width(btn_browser, 0, 0);
   lv_obj_set_style_border_width(btn_browser, 1, 0);
-  lv_obj_set_style_border_color(btn_browser, lv_color_hex(0x1a3050), 0);
+  lv_obj_set_style_border_color(btn_browser, tc(TH_BORDER), 0);
   { lv_obj_t *ico = lv_label_create(btn_browser);
     lv_label_set_text(ico, LV_SYMBOL_UPLOAD);
-    lv_obj_set_style_text_color(ico, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(ico, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(ico, &lv_font_montserrat_ext_24, 0);
     lv_obj_align(ico, LV_ALIGN_CENTER, 0, -24);
     lv_obj_t *lbl = lv_label_create(btn_browser);
     lv_label_set_text(lbl, T(STR_OTA_BROWSER));
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_18, 0);
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl, LV_ALIGN_CENTER, 0, 4);
     lv_obj_t *sub = lv_label_create(btn_browser);
     lv_label_set_text(sub, T(STR_OTA_BROWSER_SUB));
-    lv_obj_set_style_text_color(sub, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(sub, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(sub, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(sub, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(sub, LV_ALIGN_CENTER, 0, 26); }
@@ -68,26 +69,26 @@ void buildOtaScreen() {
   lv_obj_t *btn_gh = lv_btn_create(scr_ota);
   lv_obj_set_size(btn_gh, 456, 80);
   lv_obj_set_pos(btn_gh, 12, 150);
-  lv_obj_set_style_bg_color(btn_gh, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn_gh, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_gh, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn_gh, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_gh, 10, 0);
   lv_obj_set_style_shadow_width(btn_gh, 0, 0);
   lv_obj_set_style_border_width(btn_gh, 1, 0);
-  lv_obj_set_style_border_color(btn_gh, lv_color_hex(0x1a3050), 0);
+  lv_obj_set_style_border_color(btn_gh, tc(TH_BORDER), 0);
   { lv_obj_t *ico = lv_label_create(btn_gh);
     lv_label_set_text(ico, LV_SYMBOL_DOWNLOAD);
-    lv_obj_set_style_text_color(ico, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(ico, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(ico, &lv_font_montserrat_ext_24, 0);
     lv_obj_align(ico, LV_ALIGN_CENTER, 0, -24);
     lv_obj_t *lbl = lv_label_create(btn_gh);
     lv_label_set_text(lbl, T(STR_OTA_GITHUB));
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_18, 0);
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl, LV_ALIGN_CENTER, 0, 4);
     lv_obj_t *sub = lv_label_create(btn_gh);
     lv_label_set_text(sub, T(STR_OTA_GITHUB_SUB));
-    lv_obj_set_style_text_color(sub, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(sub, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(sub, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(sub, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(sub, LV_ALIGN_CENTER, 0, 26); }
@@ -100,7 +101,7 @@ void buildOtaScreen() {
   lv_obj_t *ver_ota = lv_label_create(scr_ota);
   char ver_buf[32]; snprintf(ver_buf, sizeof(ver_buf), T(STR_OTA_CURRENT), FW_VERSION);
   lv_label_set_text(ver_ota, ver_buf);
-  lv_obj_set_style_text_color(ver_ota, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(ver_ota, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(ver_ota, &lv_font_montserrat_ext_12, 0);
   lv_obj_align(ver_ota, LV_ALIGN_BOTTOM_MID, 0, -8);
 }

--- a/src/ui/reboot_popup.cpp
+++ b/src/ui/reboot_popup.cpp
@@ -5,6 +5,7 @@
 
 #include "hardware/sd_logger.h"
 #include "lang.h"
+#include "theme.h"
 
 void showRebootPopup() {
   logSD("SHOW: RebootPopup");
@@ -12,7 +13,7 @@ void showRebootPopup() {
   lv_obj_t *pop = lv_obj_create(lv_scr_act());
   lv_obj_set_size(pop, 480, 320);
   lv_obj_set_pos(pop, 0, 0);
-  lv_obj_set_style_bg_color(pop, lv_color_hex(0x000000), 0);
+  lv_obj_set_style_bg_color(pop, tc(TH_BLACK), 0);
   lv_obj_set_style_bg_opa(pop, LV_OPA_70, 0);
   lv_obj_set_style_border_width(pop, 0, 0);
   lv_obj_set_style_pad_all(pop, 0, 0);
@@ -22,7 +23,7 @@ void showRebootPopup() {
   lv_obj_set_size(box, 400, 220);
   lv_obj_align(box, LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_bg_color(box, lv_color_hex(0x0c1828), 0);
-  lv_obj_set_style_border_color(box, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_border_color(box, tc(TH_ACCENT), 0);
   lv_obj_set_style_border_width(box, 2, 0);
   lv_obj_set_style_radius(box, 12, 0);
   lv_obj_set_style_pad_all(box, 0, 0);
@@ -30,13 +31,13 @@ void showRebootPopup() {
 
   lv_obj_t *t = lv_label_create(box);
   lv_label_set_text(t, T(STR_REBOOT_TITLE));
-  lv_obj_set_style_text_color(t, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(t, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(t, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(t, LV_ALIGN_TOP_MID, 0, 16);
 
   lv_obj_t *m = lv_label_create(box);
   lv_label_set_text(m, T(STR_REBOOT_MSG));
-  lv_obj_set_style_text_color(m, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(m, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(m, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(m, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(m, LV_ALIGN_CENTER, 0, -18);
@@ -44,23 +45,23 @@ void showRebootPopup() {
   lv_obj_t *btn_rb = lv_btn_create(box);
   lv_obj_set_size(btn_rb, 180, 48);
   lv_obj_align(btn_rb, LV_ALIGN_BOTTOM_LEFT, 10, -12);
-  lv_obj_set_style_bg_color(btn_rb, lv_color_hex(0x1a3020), 0);
-  lv_obj_set_style_bg_color(btn_rb, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_rb, tc(TH_OK_BG), 0);
+  lv_obj_set_style_bg_color(btn_rb, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_rb, 8, 0);
   lv_obj_set_style_shadow_width(btn_rb, 0, 0);
   lv_obj_set_style_border_width(btn_rb, 0, 0);
   lv_obj_add_event_cb(btn_rb, [](lv_event_t *e){ logSD("Reboot: user (language/date change)"); ESP.restart(); }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *rb_lbl = lv_label_create(btn_rb);
   lv_label_set_text(rb_lbl, T(STR_REBOOT_BTN));
-  lv_obj_set_style_text_color(rb_lbl, lv_color_hex(0x40c080), 0);
+  lv_obj_set_style_text_color(rb_lbl, tc(TH_SUCCESS_TEXT), 0);
   lv_obj_set_style_text_font(rb_lbl, &lv_font_montserrat_ext_14, 0);
   lv_obj_center(rb_lbl);
 
   lv_obj_t *btn_cancel = lv_btn_create(box);
   lv_obj_set_size(btn_cancel, 180, 48);
   lv_obj_align(btn_cancel, LV_ALIGN_BOTTOM_RIGHT, -10, -12);
-  lv_obj_set_style_bg_color(btn_cancel, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_cancel, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_cancel, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_cancel, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_cancel, 8, 0);
   lv_obj_set_style_shadow_width(btn_cancel, 0, 0);
   lv_obj_set_style_border_width(btn_cancel, 0, 0);
@@ -71,7 +72,7 @@ void showRebootPopup() {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *c_lbl = lv_label_create(btn_cancel);
   lv_label_set_text(c_lbl, T(STR_CANCEL));
-  lv_obj_set_style_text_color(c_lbl, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(c_lbl, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(c_lbl, &lv_font_montserrat_ext_14, 0);
   lv_obj_center(c_lbl);
 }

--- a/src/ui/remote_link_popup.cpp
+++ b/src/ui/remote_link_popup.cpp
@@ -19,6 +19,7 @@
 #include "ui/spoolman_lookup.h"
 #include "bambu/material_match.h"
 #include "ui_common.h"
+#include "theme.h"
 
 static lv_obj_t *scr_remote_link = nullptr;
 static bool close_remote_link_pending = false;
@@ -195,7 +196,7 @@ void showRemoteLinkPopup(int spool_id) {
   scr_remote_link = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr_remote_link, 480, 320);
   lv_obj_set_pos(scr_remote_link, 0, 0);
-  lv_obj_set_style_bg_color(scr_remote_link, lv_color_hex(0x000000), 0);
+  lv_obj_set_style_bg_color(scr_remote_link, tc(TH_BLACK), 0);
   lv_obj_set_style_bg_opa(scr_remote_link, LV_OPA_80, 0);
   lv_obj_set_style_border_width(scr_remote_link, 0, 0);
   lv_obj_set_style_radius(scr_remote_link, 0, 0);
@@ -209,7 +210,7 @@ void showRemoteLinkPopup(int spool_id) {
   lv_obj_align(box, LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_bg_color(box, lv_color_hex(0x0c1828), 0);
   lv_obj_set_style_border_color(box,
-    mismatch ? lv_color_hex(0xff8080) : lv_color_hex(0x28d49a), 0);
+    mismatch ? tc(TH_DANGER_TEXT) : tc(TH_ACCENT), 0);
   lv_obj_set_style_border_width(box, 2, 0);
   lv_obj_set_style_radius(box, 12, 0);
   lv_obj_set_style_pad_all(box, 0, 0);
@@ -219,14 +220,14 @@ void showRemoteLinkPopup(int spool_id) {
   { char tb[48]; strncpy(tb, T(STR_REMOTE_LINK_TITLE), sizeof(tb) - 1);
     tb[sizeof(tb) - 1] = '\0'; lv_label_set_text(lbl_title, tb); }
   lv_obj_set_style_text_color(lbl_title,
-    mismatch ? lv_color_hex(0xff8080) : lv_color_hex(0x28d49a), 0);
+    mismatch ? tc(TH_DANGER_TEXT) : tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 14);
 
   lv_obj_t *line = lv_obj_create(box);
   lv_obj_set_size(line, 420, 1);
   lv_obj_set_pos(line, 10, 44);
-  lv_obj_set_style_bg_color(line, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(line, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(line, 0, 0);
   lv_obj_set_style_radius(line, 0, 0);
   lv_obj_set_style_pad_all(line, 0, 0);
@@ -236,7 +237,7 @@ void showRemoteLinkPopup(int spool_id) {
   lv_obj_set_size(swatch, 42, 42);
   lv_obj_set_pos(swatch, 16, 56);
   lv_obj_set_style_radius(swatch, 6, 0);
-  lv_obj_set_style_border_color(swatch, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(swatch, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(swatch, 1, 0);
   lv_obj_clear_flag(swatch, LV_OBJ_FLAG_SCROLLABLE);
   // Handles the empty and malformed cases itself, including the fallback grey.
@@ -264,7 +265,7 @@ void showRemoteLinkPopup(int spool_id) {
   }
   lv_obj_t *lbl_head = lv_label_create(box);
   lv_label_set_text(lbl_head, head);
-  lv_obj_set_style_text_color(lbl_head, lv_color_hex(0xe8f0ff), 0);
+  lv_obj_set_style_text_color(lbl_head, tc(TH_TEXT_BRIGHT), 0);
   lv_obj_set_style_text_font(lbl_head, &lv_font_montserrat_ext_16, 0);
   lv_label_set_long_mode(lbl_head, LV_LABEL_LONG_DOT);
   lv_obj_set_width(lbl_head, 250);
@@ -272,7 +273,7 @@ void showRemoteLinkPopup(int spool_id) {
 
   lv_obj_t *lbl_vendor = lv_label_create(box);
   lv_label_set_text(lbl_vendor, vendor[0] ? vendor : "-");
-  lv_obj_set_style_text_color(lbl_vendor, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_vendor, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_vendor, &lv_font_montserrat_ext_14, 0);
   lv_label_set_long_mode(lbl_vendor, LV_LABEL_LONG_DOT);
   lv_obj_set_width(lbl_vendor, 250);
@@ -283,7 +284,7 @@ void showRemoteLinkPopup(int spool_id) {
     snprintf(wbuf, sizeof(wbuf), "%.0f g", remaining);
     lv_obj_t *lbl_w = lv_label_create(box);
     lv_label_set_text(lbl_w, wbuf);
-    lv_obj_set_style_text_color(lbl_w, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(lbl_w, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(lbl_w, &lv_font_montserrat_ext_18, 0);
     lv_obj_align(lbl_w, LV_ALIGN_TOP_RIGHT, -16, 62);
   }
@@ -296,24 +297,24 @@ void showRemoteLinkPopup(int spool_id) {
 
     lv_obj_t *h_tag = lv_label_create(box);
     lv_label_set_text(h_tag, T(STR_REMOTE_LINK_COL_TAG));
-    lv_obj_set_style_text_color(h_tag, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(h_tag, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(h_tag, &lv_font_montserrat_ext_12, 0);
     lv_obj_set_pos(h_tag, COL_TAG, y_after_head);
 
     lv_obj_t *h_sp = lv_label_create(box);
     lv_label_set_text(h_sp, T(STR_REMOTE_LINK_COL_SPOOL));
-    lv_obj_set_style_text_color(h_sp, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(h_sp, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(h_sp, &lv_font_montserrat_ext_12, 0);
     lv_obj_set_pos(h_sp, COL_SPOOL, y_after_head);
 
     // Material row, values in red only where they actually differ.
     lv_obj_t *l_mat = lv_label_create(box);
     lv_label_set_text(l_mat, T(STR_REMOTE_LINK_ROW_MATERIAL));
-    lv_obj_set_style_text_color(l_mat, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(l_mat, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(l_mat, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_pos(l_mat, 16, y_after_head + 20);
 
-    uint32_t mat_col = mismatch_material ? 0xff8080 : 0xc8d8f0;
+    uint32_t mat_col = mismatch_material ? g_theme[TH_DANGER_TEXT] : g_theme[TH_TEXT];
     lv_obj_t *v_mt = lv_label_create(box);
     lv_label_set_text(v_mt, g_tag.material[0] ? g_tag.material : "?");
     lv_obj_set_style_text_color(v_mt, lv_color_hex(mat_col), 0);
@@ -333,11 +334,11 @@ void showRemoteLinkPopup(int spool_id) {
     // Colour row as two swatches, which says more than two hex strings.
     lv_obj_t *l_col = lv_label_create(box);
     lv_label_set_text(l_col, T(STR_REMOTE_LINK_ROW_COLOR));
-    lv_obj_set_style_text_color(l_col, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(l_col, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(l_col, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_pos(l_col, 16, y_after_head + 44);
 
-    uint32_t border = mismatch_color ? 0xff8080 : 0x1a3060;
+    uint32_t border = mismatch_color ? g_theme[TH_DANGER_TEXT] : g_theme[TH_SURFACE_2];
     for (int i = 0; i < 2; i++) {
       lv_obj_t *sw = lv_obj_create(box);
       lv_obj_set_size(sw, 22, 18);
@@ -357,7 +358,7 @@ void showRemoteLinkPopup(int spool_id) {
       strncpy(qb, T(STR_REMOTE_LINK_QUESTION), sizeof(qb) - 1);
       qb[sizeof(qb) - 1] = '\0';
       lv_label_set_text(lbl_q, qb); }
-    lv_obj_set_style_text_color(lbl_q, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl_q, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl_q, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(lbl_q, LV_TEXT_ALIGN_CENTER, 0);
     lv_label_set_long_mode(lbl_q, LV_LABEL_LONG_WRAP);
@@ -370,9 +371,9 @@ void showRemoteLinkPopup(int spool_id) {
   lv_obj_set_size(btn_ok, 420, 48);
   lv_obj_align(btn_ok, LV_ALIGN_TOP_MID, 0, y_after_head);
   lv_obj_set_style_bg_color(btn_ok,
-    mismatch ? lv_color_hex(0x3a1010) : lv_color_hex(0x0d3d2e), 0);
+    mismatch ? tc(TH_DANGER_BG) : lv_color_hex(0x0d3d2e), 0);
   lv_obj_set_style_bg_color(btn_ok,
-    mismatch ? lv_color_hex(0x602020) : lv_color_hex(0x18705a), LV_STATE_PRESSED);
+    mismatch ? tc(TH_DANGER_PRESSED) : lv_color_hex(0x18705a), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_ok, 8, 0);
   lv_obj_set_style_shadow_width(btn_ok, 0, 0);
   lv_obj_set_style_border_width(btn_ok, 0, 0);
@@ -387,19 +388,19 @@ void showRemoteLinkPopup(int spool_id) {
             sizeof(bb) - 1);
     bb[sizeof(bb) - 1] = '\0'; lv_label_set_text(lbl_ok, bb); }
   lv_obj_set_style_text_color(lbl_ok,
-    mismatch ? lv_color_hex(0xff8080) : lv_color_hex(0x28d49a), 0);
+    mismatch ? tc(TH_DANGER_TEXT) : tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_ok, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_ok);
 
   lv_obj_t *btn_cancel = lv_btn_create(box);
   lv_obj_set_size(btn_cancel, 420, 44);
   lv_obj_align(btn_cancel, LV_ALIGN_TOP_MID, 0, y_after_head + 56);
-  lv_obj_set_style_bg_color(btn_cancel, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_cancel, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_cancel, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_cancel, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_cancel, 8, 0);
   lv_obj_set_style_shadow_width(btn_cancel, 0, 0);
   lv_obj_set_style_border_width(btn_cancel, 1, 0);
-  lv_obj_set_style_border_color(btn_cancel, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_cancel, tc(TH_SURFACE_2), 0);
   lv_obj_add_event_cb(btn_cancel, [](lv_event_t *e) {
     s_cancel_pending = true;
     close_remote_link_pending = true;
@@ -407,7 +408,7 @@ void showRemoteLinkPopup(int spool_id) {
   lv_obj_t *lbl_cancel = lv_label_create(btn_cancel);
   { char cb[32]; strncpy(cb, T(STR_CANCEL), sizeof(cb) - 1);
     cb[sizeof(cb) - 1] = '\0'; lv_label_set_text(lbl_cancel, cb); }
-  lv_obj_set_style_text_color(lbl_cancel, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_cancel, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_cancel, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_cancel);
 }

--- a/src/ui/scale_menu.cpp
+++ b/src/ui/scale_menu.cpp
@@ -14,6 +14,7 @@
 #include "services/drying_config.h"
 #include "services/prefs_store.h"
 #include "ui_common.h"
+#include "theme.h"
 
 
 
@@ -66,7 +67,7 @@ void buildScaleSubScreen() {
     lv_obj_t *arr_lbl = lv_obj_get_child(btn, -1);
     if (arr_lbl) {
       lv_label_set_text(arr_lbl, buf_s);
-      lv_obj_set_style_text_color(arr_lbl, g_auto_loc_popup ? lv_color_hex(0x28d49a) : lv_color_hex(0x4a6fa0), 0);
+      lv_obj_set_style_text_color(arr_lbl, g_auto_loc_popup ? tc(TH_ACCENT) : tc(TH_TEXT_MUTED), 0);
       lv_obj_set_style_text_font(arr_lbl, &lv_font_montserrat_ext_14, 0);
     }
     lv_obj_add_event_cb(btn, [](lv_event_t *e){

--- a/src/ui/settings_screen.cpp
+++ b/src/ui/settings_screen.cpp
@@ -15,6 +15,7 @@
 #include "ui_common.h"
 #include "update_badges.h"
 #include "services/backend.h"
+#include "theme.h"
 
 
 void resetActivityTimer();
@@ -27,21 +28,21 @@ void buildSettingsScreen() {
 
   lv_obj_t *title = lv_label_create(scr_settings);
   lv_label_set_text(title, T(STR_SETTINGS_TITLE));
-  lv_obj_set_style_text_color(title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 12);
 
   lv_obj_t *btn_x = lv_btn_create(scr_settings);
   lv_obj_set_size(btn_x, 44, 44);
   lv_obj_align(btn_x, LV_ALIGN_TOP_RIGHT, -4, 2);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_x, 8, 0);
   lv_obj_set_style_shadow_width(btn_x, 0, 0);
   lv_obj_set_style_border_width(btn_x, 0, 0);
   lv_obj_t *lbl_x = lv_label_create(btn_x);
   lv_label_set_text(lbl_x, LV_SYMBOL_CLOSE);
-  lv_obj_set_style_text_color(lbl_x, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_x, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_x, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_x);
   lv_obj_add_event_cb(btn_x, [](lv_event_t *e){ logSD("BTN: Close -> Main"); showMainScreen(); }, LV_EVENT_CLICKED, NULL);
@@ -50,10 +51,10 @@ void buildSettingsScreen() {
   char conn_sub[40];
   backendText(T(STR_TILE_CONN_SUB), conn_sub, sizeof(conn_sub));
   struct { const char *icon; const char *label; const char *sub; uint32_t col; } tiles[] = {
-    { LV_SYMBOL_WIFI,     T(STR_TILE_CONNECTION), conn_sub,                0x0a1e30 },
-    { LV_SYMBOL_DRIVE,    T(STR_TILE_SCALE),      T(STR_TILE_SCALE_SUB),   0x0a1e30 },
-    { LV_SYMBOL_IMAGE,    T(STR_TILE_DISPLAY),    T(STR_TILE_DISPLAY_SUB), 0x0a1e30 },
-    { LV_SYMBOL_SETTINGS, T(STR_TILE_SYSTEM),     T(STR_TILE_SYSTEM_SUB),  0x0a1e30 },
+    { LV_SYMBOL_WIFI,     T(STR_TILE_CONNECTION), conn_sub,                g_theme[TH_TILE_BG] },
+    { LV_SYMBOL_DRIVE,    T(STR_TILE_SCALE),      T(STR_TILE_SCALE_SUB),   g_theme[TH_TILE_BG] },
+    { LV_SYMBOL_IMAGE,    T(STR_TILE_DISPLAY),    T(STR_TILE_DISPLAY_SUB), g_theme[TH_TILE_BG] },
+    { LV_SYMBOL_SETTINGS, T(STR_TILE_SYSTEM),     T(STR_TILE_SYSTEM_SUB),  g_theme[TH_TILE_BG] },
   };
   int tx[] = { 8, 242, 8, 242 };
   int ty[] = { 60, 60, 186, 186 };
@@ -67,27 +68,27 @@ void buildSettingsScreen() {
     lv_obj_set_size(tile, 226, 118);
     lv_obj_set_pos(tile, tx[i], ty[i]);
     lv_obj_set_style_bg_color(tile, lv_color_hex(tiles[i].col), 0);
-    lv_obj_set_style_bg_color(tile, lv_color_hex(tiles[i].col + 0x101010), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(tile, tc(TH_SURFACE_2), LV_STATE_PRESSED);
     lv_obj_set_style_radius(tile, 10, 0);
     lv_obj_set_style_shadow_width(tile, 0, 0);
     lv_obj_set_style_border_width(tile, 1, 0);
-    lv_obj_set_style_border_color(tile, lv_color_hex(tiles[i].col + 0x181818), 0);
+    lv_obj_set_style_border_color(tile, tc(TH_BORDER), 0);
 
     lv_obj_t *ico = lv_label_create(tile);
     lv_label_set_text(ico, tiles[i].icon);
-    lv_obj_set_style_text_color(ico, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(ico, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(ico, &lv_font_montserrat_ext_24, 0);
     lv_obj_align(ico, LV_ALIGN_TOP_LEFT, 10, 8);
 
     lv_obj_t *lbl = lv_label_create(tile);
     lv_label_set_text(lbl, tiles[i].label);
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_18, 0);
     lv_obj_align(lbl, LV_ALIGN_CENTER, 0, -8);
 
     lv_obj_t *sub = lv_label_create(tile);
     lv_label_set_text(sub, tiles[i].sub);
-    lv_obj_set_style_text_color(sub, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(sub, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(sub, &lv_font_montserrat_ext_12, 0);
     lv_obj_align(sub, LV_ALIGN_CENTER, 0, 16);
 

--- a/src/ui/setup_welcome_screen.cpp
+++ b/src/ui/setup_welcome_screen.cpp
@@ -13,6 +13,7 @@
 #include "ui_common.h"
 #include "wifi_setup_screen.h"
 #include "services/backend.h"
+#include "theme.h"
 
 
 
@@ -35,23 +36,23 @@ void buildWelcomeScreen() {
   lv_obj_set_style_border_width(scr_welcome, 0, 0);
   lv_obj_set_style_pad_all(scr_welcome, 0, 0);
   lv_obj_clear_flag(scr_welcome, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr_welcome, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_welcome, tc(TH_BG), 0);
 
   lv_obj_t *lbl_logo = lv_label_create(scr_welcome);
   lv_label_set_text(lbl_logo, "SpoolmanScale");
-  lv_obj_set_style_text_color(lbl_logo, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_logo, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_logo, &lv_font_montserrat_ext_24, 0);
   lv_obj_align(lbl_logo, LV_ALIGN_TOP_MID, 0, 24);
 
   lv_obj_t *lbl_sub = lv_label_create(scr_welcome);
   lv_label_set_text(lbl_sub, T(STR_WELCOME_LANG_TITLE));
-  lv_obj_set_style_text_color(lbl_sub, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_sub, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_sub, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(lbl_sub, LV_ALIGN_TOP_MID, 0, 64);
 
   lv_obj_t *lbl_hint = lv_label_create(scr_welcome);
   lv_label_set_text(lbl_hint, T(STR_WELCOME_LANG_HINT));
-  lv_obj_set_style_text_color(lbl_hint, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(lbl_hint, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(lbl_hint, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(lbl_hint, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_hint, LV_LABEL_LONG_WRAP);
@@ -62,14 +63,14 @@ void buildWelcomeScreen() {
     lv_obj_t *btn_x = lv_btn_create(scr_welcome);
     lv_obj_set_size(btn_x, 44, 44);
     lv_obj_align(btn_x, LV_ALIGN_TOP_RIGHT, -4, 2);
-    lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x3a1010), 0);
-    lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x602020), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_BG), 0);
+    lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_x, 8, 0);
     lv_obj_set_style_shadow_width(btn_x, 0, 0);
     lv_obj_set_style_border_width(btn_x, 0, 0);
     lv_obj_t *lbl_x = lv_label_create(btn_x);
     lv_label_set_text(lbl_x, LV_SYMBOL_CLOSE);
-    lv_obj_set_style_text_color(lbl_x, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_x, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(lbl_x, &lv_font_montserrat_ext_18, 0);
     lv_obj_center(lbl_x);
     lv_obj_add_event_cb(btn_x, [](lv_event_t *e){ logSD("BTN: Close -> Main"); showMainScreen(); }, LV_EVENT_CLICKED, NULL);
@@ -85,10 +86,10 @@ void buildWelcomeScreen() {
   lv_obj_set_style_radius(btn_en, 10, 0);
   lv_obj_set_style_shadow_width(btn_en, 0, 0);
   lv_obj_set_style_border_width(btn_en, 2, 0);
-  lv_obj_set_style_border_color(btn_en, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_border_color(btn_en, tc(TH_ACCENT), 0);
   lv_obj_t *lbl_en = lv_label_create(btn_en);
   lv_label_set_text(lbl_en, "EN   English");
-  lv_obj_set_style_text_color(lbl_en, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_en, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_en, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_en);
   lv_obj_add_event_cb(btn_en, [](lv_event_t *e){
@@ -104,15 +105,15 @@ void buildWelcomeScreen() {
   lv_obj_t *btn_de = lv_btn_create(scr_welcome);
   lv_obj_set_size(btn_de, LB_W, LB_H);
   lv_obj_set_pos(btn_de, 254, LB_Y);
-  lv_obj_set_style_bg_color(btn_de, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_de, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_de, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_de, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_de, 10, 0);
   lv_obj_set_style_shadow_width(btn_de, 0, 0);
   lv_obj_set_style_border_width(btn_de, 2, 0);
-  lv_obj_set_style_border_color(btn_de, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_de, tc(TH_SURFACE_2), 0);
   lv_obj_t *lbl_de = lv_label_create(btn_de);
   lv_label_set_text(lbl_de, "DE   Deutsch");
-  lv_obj_set_style_text_color(lbl_de, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_de, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_de, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_de);
   lv_obj_add_event_cb(btn_de, [](lv_event_t *e){
@@ -125,7 +126,7 @@ void buildWelcomeScreen() {
 
   lv_obj_t *lbl_skip = lv_label_create(scr_welcome);
   lv_label_set_text(lbl_skip, T(STR_LANG_HINT));
-  lv_obj_set_style_text_color(lbl_skip, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(lbl_skip, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(lbl_skip, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(lbl_skip, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_skip, LV_ALIGN_BOTTOM_MID, 0, -10);
@@ -150,23 +151,23 @@ void buildFirstBootScreen() {
   lv_obj_set_style_border_width(scr_first_boot, 0, 0);
   lv_obj_set_style_pad_all(scr_first_boot, 0, 0);
   lv_obj_clear_flag(scr_first_boot, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr_first_boot, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_first_boot, tc(TH_BG), 0);
 
   lv_obj_t *lbl_logo = lv_label_create(scr_first_boot);
   lv_label_set_text(lbl_logo, "SpoolmanScale");
-  lv_obj_set_style_text_color(lbl_logo, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_logo, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_logo, &lv_font_montserrat_ext_24, 0);
   lv_obj_align(lbl_logo, LV_ALIGN_TOP_MID, 0, 32);
 
   lv_obj_t *lbl_title = lv_label_create(scr_first_boot);
   lv_label_set_text(lbl_title, T(STR_FIRSTBOOT_TITLE));
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0xe8f0ff), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_TEXT_BRIGHT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_20, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 72);
 
   lv_obj_t *lbl_sub = lv_label_create(scr_first_boot);
   lv_label_set_text(lbl_sub, T(STR_FIRSTBOOT_SUB));
-  lv_obj_set_style_text_color(lbl_sub, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_sub, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_sub, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_sub, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_sub, LV_ALIGN_TOP_MID, 0, 104);
@@ -177,7 +178,7 @@ void buildFirstBootScreen() {
   // "FilaMan/FilaMan" once a mode is stored.
   { char hb[128]; strncpy(hb, T(STR_FIRSTBOOT_HINT), sizeof(hb) - 1); hb[sizeof(hb) - 1] = '\0';
     lv_label_set_text(lbl_hint, hb); }
-  lv_obj_set_style_text_color(lbl_hint, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_hint, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_hint, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_hint, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_hint, LV_LABEL_LONG_WRAP);
@@ -188,15 +189,15 @@ void buildFirstBootScreen() {
     lv_obj_t *btn_cx = lv_btn_create(scr_first_boot);
     lv_obj_set_size(btn_cx, 44, 44);
     lv_obj_align(btn_cx, LV_ALIGN_TOP_RIGHT, -4, 2);
-    lv_obj_set_style_bg_color(btn_cx, lv_color_hex(0x3a1010), 0);
-    lv_obj_set_style_bg_color(btn_cx, lv_color_hex(0x602020), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_cx, tc(TH_DANGER_BG), 0);
+    lv_obj_set_style_bg_color(btn_cx, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_cx, 8, 0);
     lv_obj_set_style_shadow_width(btn_cx, 0, 0);
     lv_obj_set_style_border_width(btn_cx, 0, 0);
     lv_obj_add_event_cb(btn_cx, [](lv_event_t *e){ logSD("BTN: Close -> Main"); showMainScreen(); }, LV_EVENT_CLICKED, NULL);
     lv_obj_t *lbl_cx = lv_label_create(btn_cx);
     lv_label_set_text(lbl_cx, LV_SYMBOL_CLOSE);
-    lv_obj_set_style_text_color(lbl_cx, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_cx, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(lbl_cx, &lv_font_montserrat_ext_18, 0);
     lv_obj_center(lbl_cx);
   }
@@ -204,12 +205,12 @@ void buildFirstBootScreen() {
   lv_obj_t *btn_start = lv_btn_create(scr_first_boot);
   lv_obj_set_size(btn_start, 226, 48);
   lv_obj_set_pos(btn_start, 12, 252);
-  lv_obj_set_style_bg_color(btn_start, lv_color_hex(0x1a3020), 0);
-  lv_obj_set_style_bg_color(btn_start, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_start, tc(TH_OK_BG), 0);
+  lv_obj_set_style_bg_color(btn_start, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_start, 10, 0);
   lv_obj_set_style_shadow_width(btn_start, 0, 0);
   lv_obj_set_style_border_width(btn_start, 1, 0);
-  lv_obj_set_style_border_color(btn_start, lv_color_hex(0x2a5030), 0);
+  lv_obj_set_style_border_color(btn_start, tc(TH_SUCCESS_BG), 0);
   lv_obj_add_event_cb(btn_start, [](lv_event_t *e) {
     prefsPutBool("first_boot", false);
     cfg_first_boot = false;
@@ -217,7 +218,7 @@ void buildFirstBootScreen() {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_start = lv_label_create(btn_start);
   lv_label_set_text(lbl_start, T(STR_FIRSTBOOT_BTN));
-  lv_obj_set_style_text_color(lbl_start, lv_color_hex(0x40c080), 0);
+  lv_obj_set_style_text_color(lbl_start, tc(TH_SUCCESS_TEXT), 0);
   lv_obj_set_style_text_font(lbl_start, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_start, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_start, LV_ALIGN_CENTER, 0, 0);
@@ -225,12 +226,12 @@ void buildFirstBootScreen() {
   lv_obj_t *btn_skip = lv_btn_create(scr_first_boot);
   lv_obj_set_size(btn_skip, 226, 48);
   lv_obj_set_pos(btn_skip, 242, 252);
-  lv_obj_set_style_bg_color(btn_skip, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_skip, lv_color_hex(0x1a2840), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_skip, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_skip, tc(TH_SURFACE_3), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_skip, 10, 0);
   lv_obj_set_style_shadow_width(btn_skip, 0, 0);
   lv_obj_set_style_border_width(btn_skip, 1, 0);
-  lv_obj_set_style_border_color(btn_skip, lv_color_hex(0x1a2840), 0);
+  lv_obj_set_style_border_color(btn_skip, tc(TH_SURFACE_3), 0);
   lv_obj_add_event_cb(btn_skip, [](lv_event_t *e) {
     skip_setup_pending = true;
   }, LV_EVENT_CLICKED, NULL);
@@ -238,7 +239,7 @@ void buildFirstBootScreen() {
   char skip_buf[32];
   strncpy(skip_buf, T(STR_BTN_SKIP_SETUP), sizeof(skip_buf)-1);
   lv_label_set_text(lbl_skip, skip_buf);
-  lv_obj_set_style_text_color(lbl_skip, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_skip, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_skip, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_skip, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_skip, LV_ALIGN_CENTER, 0, 0);

--- a/src/ui/spool_flow.cpp
+++ b/src/ui/spool_flow.cpp
@@ -19,6 +19,7 @@
 #include "ui/spoolman_lookup.h"
 #include "ui/ui_common.h"
 #include "services/backend.h"
+#include "theme.h"
 
 namespace {
 
@@ -451,7 +452,7 @@ void doLinkPatch(int spool_id, bool is_bambu) {
       strncpy(buf, T(STR_LINK_NO_TAG), sizeof(buf) - 1);
       buf[sizeof(buf) - 1] = '\0';
       lv_label_set_text(lbl_status, buf);
-      lv_obj_set_style_text_color(lbl_status, lv_color_hex(0xff8080), 0);
+      lv_obj_set_style_text_color(lbl_status, tc(TH_DANGER_TEXT), 0);
     }
     closeLinkOverlays();
     return;
@@ -484,7 +485,7 @@ static lv_obj_t* buildLinkOverlay() {
   lv_obj_t *scr = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr, 480, 320);
   lv_obj_set_pos(scr, 0, 0);
-  lv_obj_set_style_bg_color(scr, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr, tc(TH_BG), 0);
   lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, 0);
   lv_obj_set_style_border_width(scr, 0, 0);
   lv_obj_set_style_radius(scr, 0, 0);
@@ -503,7 +504,7 @@ void showWarnPopupA(int spool_id, const char* existing_tag, bool is_bambu, const
   scr_link_warn_a = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr_link_warn_a, 480, 320);
   lv_obj_set_pos(scr_link_warn_a, 0, 0);
-  lv_obj_set_style_bg_color(scr_link_warn_a, lv_color_hex(0x000000), 0);
+  lv_obj_set_style_bg_color(scr_link_warn_a, tc(TH_BLACK), 0);
   lv_obj_set_style_bg_opa(scr_link_warn_a, LV_OPA_80, 0);
   lv_obj_set_style_border_width(scr_link_warn_a, 0, 0);
   lv_obj_set_style_radius(scr_link_warn_a, 0, 0);
@@ -514,7 +515,7 @@ void showWarnPopupA(int spool_id, const char* existing_tag, bool is_bambu, const
   lv_obj_set_size(box, 440, 262);
   lv_obj_align(box, LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_bg_color(box, lv_color_hex(0x0c1828), 0);
-  lv_obj_set_style_border_color(box, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_border_color(box, tc(TH_WARNING), 0);
   lv_obj_set_style_border_width(box, 2, 0);
   lv_obj_set_style_radius(box, 12, 0);
   lv_obj_set_style_pad_all(box, 0, 0);
@@ -523,7 +524,7 @@ void showWarnPopupA(int spool_id, const char* existing_tag, bool is_bambu, const
   // Warning icon + title
   lv_obj_t *lbl_title = lv_label_create(box);
   lv_label_set_text(lbl_title, T(STR_WARN_A_TITLE));
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_title, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 16);
@@ -560,7 +561,7 @@ void showWarnPopupA(int spool_id, const char* existing_tag, bool is_bambu, const
   }
   lv_obj_t *lbl_info = lv_label_create(box);
   lv_label_set_text(lbl_info, info_buf);
-  lv_obj_set_style_text_color(lbl_info, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_info, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_info, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_info, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_info, LV_LABEL_LONG_WRAP);
@@ -590,19 +591,19 @@ void showWarnPopupA(int spool_id, const char* existing_tag, bool is_bambu, const
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_force = lv_label_create(btn_force);
   lv_label_set_text(lbl_force, T(STR_BTN_OVERWRITE));
-  lv_obj_set_style_text_color(lbl_force, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_force, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_force, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_force);
 
   lv_obj_t *btn_retry = lv_btn_create(box);
   lv_obj_set_size(btn_retry, 420, 44);
   lv_obj_set_pos(btn_retry, 10, 166);  // 114+44+8
-  lv_obj_set_style_bg_color(btn_retry, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_retry, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_retry, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_retry, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_retry, 8, 0);
   lv_obj_set_style_shadow_width(btn_retry, 0, 0);
   lv_obj_set_style_border_width(btn_retry, 1, 0);
-  lv_obj_set_style_border_color(btn_retry, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_retry, tc(TH_SURFACE_2), 0);
   lv_obj_add_event_cb(btn_retry, [](lv_event_t *e) {
     logSD("BTN: WarnA -> retry IdInput (flag)");
     if (scr_link_warn_a) { lv_obj_del(scr_link_warn_a); scr_link_warn_a = nullptr; }
@@ -613,15 +614,15 @@ void showWarnPopupA(int spool_id, const char* existing_tag, bool is_bambu, const
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_retry = lv_label_create(btn_retry);
   lv_label_set_text(lbl_retry, T(STR_ENTER_NEW_ID));
-  lv_obj_set_style_text_color(lbl_retry, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_retry, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_retry, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_retry);
 
   lv_obj_t *btn_cancel = lv_btn_create(box);
   lv_obj_set_size(btn_cancel, 420, 36);
   lv_obj_set_pos(btn_cancel, 10, 218);  // 166+44+8
-  lv_obj_set_style_bg_color(btn_cancel, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_cancel, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_cancel, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_cancel, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_cancel, 8, 0);
   lv_obj_set_style_shadow_width(btn_cancel, 0, 0);
   lv_obj_set_style_border_width(btn_cancel, 0, 0);
@@ -631,7 +632,7 @@ void showWarnPopupA(int spool_id, const char* existing_tag, bool is_bambu, const
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_cancel = lv_label_create(btn_cancel);
   lv_label_set_text(lbl_cancel, T(STR_CANCEL));
-  lv_obj_set_style_text_color(lbl_cancel, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_cancel, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_cancel, &lv_font_montserrat_ext_14, 0);
   lv_obj_center(lbl_cancel);
 }
@@ -652,7 +653,7 @@ void showWarnPopupB(int spool_id, bool is_bambu) {
   scr_link_warn_b = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr_link_warn_b, 480, 320);
   lv_obj_set_pos(scr_link_warn_b, 0, 0);
-  lv_obj_set_style_bg_color(scr_link_warn_b, lv_color_hex(0x000000), 0);
+  lv_obj_set_style_bg_color(scr_link_warn_b, tc(TH_BLACK), 0);
   lv_obj_set_style_bg_opa(scr_link_warn_b, LV_OPA_80, 0);
   lv_obj_set_style_border_width(scr_link_warn_b, 0, 0);
   lv_obj_set_style_radius(scr_link_warn_b, 0, 0);
@@ -663,7 +664,7 @@ void showWarnPopupB(int spool_id, bool is_bambu) {
   lv_obj_set_size(box, 440, 260);
   lv_obj_align(box, LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_bg_color(box, lv_color_hex(0x0c1828), 0);
-  lv_obj_set_style_border_color(box, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_border_color(box, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_border_width(box, 2, 0);
   lv_obj_set_style_radius(box, 12, 0);
   lv_obj_set_style_pad_all(box, 0, 0);
@@ -671,7 +672,7 @@ void showWarnPopupB(int spool_id, bool is_bambu) {
 
   lv_obj_t *lbl_title = lv_label_create(box);
   lv_label_set_text(lbl_title, T(STR_WARN_B_TITLE));
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_title, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 16);
@@ -679,7 +680,7 @@ void showWarnPopupB(int spool_id, bool is_bambu) {
   lv_obj_t *line = lv_obj_create(box);
   lv_obj_set_size(line, 420, 1);
   lv_obj_set_pos(line, 10, 42);
-  lv_obj_set_style_bg_color(line, lv_color_hex(0x3a1010), 0);
+  lv_obj_set_style_bg_color(line, tc(TH_DANGER_BG), 0);
   lv_obj_set_style_border_width(line, 0, 0);
   lv_obj_set_style_radius(line, 0, 0);
   lv_obj_set_style_pad_all(line, 0, 0);
@@ -696,7 +697,7 @@ void showWarnPopupB(int spool_id, bool is_bambu) {
     g_tag.material[0] ? g_tag.material : "?", sm_mat, spool_id);
   lv_obj_t *lbl_info = lv_label_create(box);
   lv_label_set_text(lbl_info, mat_buf);
-  lv_obj_set_style_text_color(lbl_info, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_info, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_info, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_info, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_info, LV_LABEL_LONG_WRAP);
@@ -706,8 +707,8 @@ void showWarnPopupB(int spool_id, bool is_bambu) {
   lv_obj_t *btn_force = lv_btn_create(box);
   lv_obj_set_size(btn_force, 420, 48);
   lv_obj_align(btn_force, LV_ALIGN_TOP_MID, 0, 142);
-  lv_obj_set_style_bg_color(btn_force, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_force, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_force, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_force, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_force, 8, 0);
   lv_obj_set_style_shadow_width(btn_force, 0, 0);
   lv_obj_set_style_border_width(btn_force, 0, 0);
@@ -718,19 +719,19 @@ void showWarnPopupB(int spool_id, bool is_bambu) {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_force = lv_label_create(btn_force);
   lv_label_set_text(lbl_force, T(STR_BTN_OVERWRITE));
-  lv_obj_set_style_text_color(lbl_force, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_force, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_force, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_force);
 
   lv_obj_t *btn_retry = lv_btn_create(box);
   lv_obj_set_size(btn_retry, 420, 44);
   lv_obj_align(btn_retry, LV_ALIGN_TOP_MID, 0, 198);
-  lv_obj_set_style_bg_color(btn_retry, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_retry, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_retry, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_retry, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_retry, 8, 0);
   lv_obj_set_style_shadow_width(btn_retry, 0, 0);
   lv_obj_set_style_border_width(btn_retry, 1, 0);
-  lv_obj_set_style_border_color(btn_retry, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_retry, tc(TH_SURFACE_2), 0);
   lv_obj_add_event_cb(btn_retry, [](lv_event_t *e) {
     if (scr_link_warn_b) { lv_obj_del(scr_link_warn_b); scr_link_warn_b = nullptr; }
     link_id_input[0] = '\0';
@@ -738,14 +739,14 @@ void showWarnPopupB(int spool_id, bool is_bambu) {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_retry = lv_label_create(btn_retry);
   lv_label_set_text(lbl_retry, T(STR_ENTER_NEW_ID));
-  lv_obj_set_style_text_color(lbl_retry, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_retry, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_retry, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_retry);
 
   lv_obj_t *btn_cancel = lv_btn_create(box);
   lv_obj_set_size(btn_cancel, 420, 36);
   lv_obj_align(btn_cancel, LV_ALIGN_BOTTOM_MID, 0, -8);
-  lv_obj_set_style_bg_color(btn_cancel, lv_color_hex(0x1a2030), 0);
+  lv_obj_set_style_bg_color(btn_cancel, tc(TH_SURFACE_DARK), 0);
   lv_obj_set_style_bg_color(btn_cancel, lv_color_hex(0x2a3040), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_cancel, 8, 0);
   lv_obj_set_style_shadow_width(btn_cancel, 0, 0);
@@ -756,7 +757,7 @@ void showWarnPopupB(int spool_id, bool is_bambu) {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_cancel = lv_label_create(btn_cancel);
   lv_label_set_text(lbl_cancel, T(STR_CANCEL));
-  lv_obj_set_style_text_color(lbl_cancel, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_cancel, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_cancel, &lv_font_montserrat_ext_14, 0);
   lv_obj_center(lbl_cancel);
 }
@@ -856,7 +857,7 @@ void showIdInputPopup(bool is_bambu, bool is_copy) {
   // Title zentriert
   lv_obj_t *lbl_title = lv_label_create(scr_link_id);
   { char tb[40]; backendText(T(STR_LINK_ID_TITLE), tb, sizeof(tb)); lv_label_set_text(lbl_title, tb); }
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 12);
 
@@ -864,8 +865,8 @@ void showIdInputPopup(bool is_bambu, bool is_copy) {
   lv_obj_t *btn_back = lv_btn_create(scr_link_id);
   lv_obj_set_size(btn_back, 44, 44);
   lv_obj_set_pos(btn_back, 4, 2);
-  lv_obj_set_style_bg_color(btn_back, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_back, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_back, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_back, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_back, 8, 0);
   lv_obj_set_style_shadow_width(btn_back, 0, 0);
   lv_obj_set_style_border_width(btn_back, 0, 0);
@@ -887,7 +888,7 @@ void showIdInputPopup(bool is_bambu, bool is_copy) {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_bk = lv_label_create(btn_back);
   lv_label_set_text(lbl_bk, LV_SYMBOL_LEFT);
-  lv_obj_set_style_text_color(lbl_bk, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_bk, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_bk, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_bk);
 
@@ -895,8 +896,8 @@ void showIdInputPopup(bool is_bambu, bool is_copy) {
   lv_obj_t *btn_x = lv_btn_create(scr_link_id);
   lv_obj_set_size(btn_x, 44, 44);
   lv_obj_align(btn_x, LV_ALIGN_TOP_RIGHT, -4, 2);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_x, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_x, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_x, 8, 0);
   lv_obj_set_style_shadow_width(btn_x, 0, 0);
   lv_obj_set_style_border_width(btn_x, 0, 0);
@@ -916,14 +917,14 @@ void showIdInputPopup(bool is_bambu, bool is_copy) {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_x = lv_label_create(btn_x);
   lv_label_set_text(lbl_x, LV_SYMBOL_CLOSE);
-  lv_obj_set_style_text_color(lbl_x, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_x, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_x, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_x);
 
   // Separator line
   lv_obj_t *div = lv_obj_create(scr_link_id);
   lv_obj_set_size(div, 472, 1); lv_obj_set_pos(div, 4, 48);
-  lv_obj_set_style_bg_color(div, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(div, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(div, 0, 0);
   lv_obj_set_style_radius(div, 0, 0);
   lv_obj_set_style_pad_all(div, 0, 0);
@@ -937,7 +938,7 @@ void showIdInputPopup(bool is_bambu, bool is_copy) {
     snprintf(ctx_buf, sizeof(ctx_buf), "UID: %.14s", link_tag_uid);
   }
   lv_label_set_text(lbl_ctx, ctx_buf);
-  lv_obj_set_style_text_color(lbl_ctx, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_ctx, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_ctx, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_ctx, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_ctx, LV_ALIGN_TOP_MID, 0, 56);
@@ -946,8 +947,8 @@ void showIdInputPopup(bool is_bambu, bool is_copy) {
   lv_obj_t *input_box = lv_obj_create(scr_link_id);
   lv_obj_set_size(input_box, 260, 44);
   lv_obj_align(input_box, LV_ALIGN_TOP_MID, 0, 76);
-  lv_obj_set_style_bg_color(input_box, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_border_color(input_box, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_bg_color(input_box, tc(TH_SURFACE), 0);
+  lv_obj_set_style_border_color(input_box, tc(TH_ACCENT), 0);
   lv_obj_set_style_border_width(input_box, 1, 0);
   lv_obj_set_style_radius(input_box, 6, 0);
   lv_obj_set_style_pad_all(input_box, 0, 0);
@@ -955,7 +956,7 @@ void showIdInputPopup(bool is_bambu, bool is_copy) {
 
   lbl_link_id_display = lv_label_create(input_box);
   lv_label_set_text(lbl_link_id_display, link_id_input[0] ? link_id_input : "_");
-  lv_obj_set_style_text_color(lbl_link_id_display, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_link_id_display, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_link_id_display, &lv_font_montserrat_ext_24, 0);
   lv_obj_set_style_text_align(lbl_link_id_display, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_center(lbl_link_id_display);
@@ -963,7 +964,7 @@ void showIdInputPopup(bool is_bambu, bool is_copy) {
   // Status label inside input box (replaces digit display when error occurs)
   lbl_link_id_status = lv_label_create(input_box);
   lv_label_set_text(lbl_link_id_status, "");
-  lv_obj_set_style_text_color(lbl_link_id_status, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_link_id_status, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_link_id_status, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(lbl_link_id_status, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_link_id_status, LV_ALIGN_BOTTOM_MID, 0, -2);
@@ -992,10 +993,10 @@ void showIdInputPopup(bool is_bambu, bool is_copy) {
 
     bool is_ok        = (d == 11);
     bool is_backspace = (d == 10);
-    uint32_t bg_col = is_ok ? 0x1a3020 : 0x0a1e30;
-    uint32_t bg_pr  = is_ok ? 0x2a5030 : 0x1a3060;
-    uint32_t bd_col = is_ok ? 0x2a5030 : 0x1a3060;
-    uint32_t tx_col = is_ok ? 0x40c080 : (is_backspace ? 0xf0b838 : 0xe8f0ff);
+    uint32_t bg_col = is_ok ? g_theme[TH_OK_BG] : g_theme[TH_TILE_BG];
+    uint32_t bg_pr  = is_ok ? g_theme[TH_SUCCESS_BG] : g_theme[TH_SURFACE_2];
+    uint32_t bd_col = is_ok ? g_theme[TH_SUCCESS_BG] : g_theme[TH_SURFACE_2];
+    uint32_t tx_col = is_ok ? g_theme[TH_SUCCESS_TEXT] : (is_backspace ? g_theme[TH_WARNING] : g_theme[TH_TEXT_BRIGHT]);
 
     lv_obj_set_style_bg_color(btn, lv_color_hex(bg_col), 0);
     lv_obj_set_style_bg_color(btn, lv_color_hex(bg_pr), LV_STATE_PRESSED);
@@ -1082,7 +1083,7 @@ static void addListMoreInfo(lv_obj_t* list, StringID str_id) {
 
   lv_obj_t *lbl = lv_label_create(row);
   lv_label_set_text(lbl, buf);
-  lv_obj_set_style_text_color(lbl, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_12, 0);
   lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl, LV_LABEL_LONG_WRAP);
@@ -1138,7 +1139,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
   lv_obj_t *hdr = lv_obj_create(scr_link_spools);
   lv_obj_set_size(hdr, 480, 52);
   lv_obj_set_pos(hdr, 0, 0);
-  lv_obj_set_style_bg_color(hdr, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(hdr, tc(TH_BG), 0);
   lv_obj_set_style_border_width(hdr, 0, 0);
   lv_obj_set_style_pad_all(hdr, 0, 0);
   lv_obj_set_style_radius(hdr, 0, 0);
@@ -1146,7 +1147,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
 
   lv_obj_t *lbl_title = lv_label_create(hdr);
   lv_label_set_text(lbl_title, title_buf);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(lbl_title, LV_ALIGN_CENTER, 0, 0);
 
@@ -1154,8 +1155,8 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
   lv_obj_t *btn_hdr_back = lv_btn_create(hdr);
   lv_obj_set_size(btn_hdr_back, 44, 44);
   lv_obj_set_pos(btn_hdr_back, 4, 4);
-  lv_obj_set_style_bg_color(btn_hdr_back, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_hdr_back, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_hdr_back, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_hdr_back, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_hdr_back, 8, 0);
   lv_obj_set_style_shadow_width(btn_hdr_back, 0, 0);
   lv_obj_set_style_border_width(btn_hdr_back, 0, 0);
@@ -1176,7 +1177,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
   }, LV_EVENT_CLICKED, NULL);
   { lv_obj_t *l = lv_label_create(btn_hdr_back);
     lv_label_set_text(l, LV_SYMBOL_LEFT);
-    lv_obj_set_style_text_color(l, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(l, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_18, 0);
     lv_obj_center(l); }
 
@@ -1184,8 +1185,8 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
   lv_obj_t *btn_hdr_cancel = lv_btn_create(hdr);
   lv_obj_set_size(btn_hdr_cancel, 44, 44);
   lv_obj_align(btn_hdr_cancel, LV_ALIGN_RIGHT_MID, -4, 0);
-  lv_obj_set_style_bg_color(btn_hdr_cancel, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_hdr_cancel, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_hdr_cancel, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_hdr_cancel, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_hdr_cancel, 8, 0);
   lv_obj_set_style_shadow_width(btn_hdr_cancel, 0, 0);
   lv_obj_set_style_border_width(btn_hdr_cancel, 0, 0);
@@ -1199,14 +1200,14 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
   }, LV_EVENT_CLICKED, NULL);
   { lv_obj_t *l = lv_label_create(btn_hdr_cancel);
     lv_label_set_text(l, LV_SYMBOL_CLOSE);
-    lv_obj_set_style_text_color(l, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(l, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_18, 0);
     lv_obj_center(l); }
 
   // Separator
   lv_obj_t *div = lv_obj_create(scr_link_spools);
   lv_obj_set_size(div, 480, 1); lv_obj_set_pos(div, 0, 52);
-  lv_obj_set_style_bg_color(div, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(div, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(div, 0, 0);
   lv_obj_set_style_radius(div, 0, 0);
   lv_obj_set_style_pad_all(div, 0, 0);
@@ -1215,7 +1216,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
   lv_obj_t *list = lv_obj_create(scr_link_spools);
   lv_obj_set_size(list, 460, 264);
   lv_obj_set_pos(list, 10, 56);
-  lv_obj_set_style_bg_color(list, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(list, tc(TH_BG), 0);
   lv_obj_set_style_border_width(list, 0, 0);
   lv_obj_set_style_pad_all(list, 2, 0);
   lv_obj_set_style_radius(list, 0, 0);
@@ -1254,19 +1255,19 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
     count++;
     lv_obj_t *row = lv_btn_create(list);
     lv_obj_set_size(row, 452, 56);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE), 0);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE_2), LV_STATE_PRESSED);
     lv_obj_set_style_radius(row, 6, 0);
     lv_obj_set_style_shadow_width(row, 0, 0);
     lv_obj_set_style_border_width(row, 1, 0);
-    lv_obj_set_style_border_color(row, lv_color_hex(0x1a2840), 0);
+    lv_obj_set_style_border_color(row, tc(TH_SURFACE_3), 0);
     lv_obj_set_style_pad_all(row, 0, 0);
 
     // ── Zeile 1: #ID + Material+Name ──────────────────────
     lv_obj_t *lbl_id = lv_label_create(row);
     char id_buf[10]; snprintf(id_buf, sizeof(id_buf), "%d", s.id);
     lv_label_set_text(lbl_id, id_buf);
-    lv_obj_set_style_text_color(lbl_id, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(lbl_id, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(lbl_id, &lv_font_montserrat_ext_16, 0);
     lv_obj_align(lbl_id, LV_ALIGN_TOP_LEFT, 6, 5);
 
@@ -1286,7 +1287,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
     }
     full_name[sizeof(full_name)-1] = '\0';
     lv_label_set_text(lbl_name, full_name);
-    lv_obj_set_style_text_color(lbl_name, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl_name, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl_name, &lv_font_montserrat_ext_16, 0);
     lv_obj_align(lbl_name, LV_ALIGN_TOP_LEFT, 50, 5);
     lv_label_set_long_mode(lbl_name, LV_LABEL_LONG_DOT);
@@ -1299,7 +1300,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
     lv_obj_align(swatch, LV_ALIGN_BOTTOM_LEFT, 6, -6);
     lv_obj_set_style_radius(swatch, 3, 0);
     lv_obj_set_style_border_width(swatch, 1, 0);
-    lv_obj_set_style_border_color(swatch, lv_color_hex(0x2a4060), 0);
+    lv_obj_set_style_border_color(swatch, tc(TH_TEXT_DIM), 0);
     lv_obj_set_style_pad_all(swatch, 0, 0);
     lv_obj_clear_flag(swatch, LV_OBJ_FLAG_SCROLLABLE);
     // Farbe setzen
@@ -1313,7 +1314,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
     else
       snprintf(rest_buf, sizeof(rest_buf), "%.0fg", s.remaining);
     lv_label_set_text(lbl_rest, rest_buf);
-    lv_obj_set_style_text_color(lbl_rest, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl_rest, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl_rest, &lv_font_montserrat_ext_14, 0);
     lv_obj_align(lbl_rest, LV_ALIGN_BOTTOM_LEFT, 26, -5);
 
@@ -1327,7 +1328,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
       lv_obj_t *popup = lv_obj_create(lv_scr_act());
       lv_obj_set_size(popup, 480, 320);
       lv_obj_set_pos(popup, 0, 0);
-      lv_obj_set_style_bg_color(popup, lv_color_hex(0x000000), 0);
+      lv_obj_set_style_bg_color(popup, tc(TH_BLACK), 0);
       lv_obj_set_style_bg_opa(popup, LV_OPA_70, 0);
       lv_obj_set_style_border_width(popup, 0, 0);
       lv_obj_set_style_radius(popup, 0, 0);
@@ -1338,7 +1339,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
       lv_obj_set_size(box, 440, 220);
       lv_obj_align(box, LV_ALIGN_CENTER, 0, 0);
       lv_obj_set_style_bg_color(box, lv_color_hex(0x0c1828), 0);
-      lv_obj_set_style_border_color(box, lv_color_hex(0x28d49a), 0);
+      lv_obj_set_style_border_color(box, tc(TH_ACCENT), 0);
       lv_obj_set_style_border_width(box, 2, 0);
       lv_obj_set_style_radius(box, 12, 0);
       lv_obj_set_style_pad_all(box, 0, 0);
@@ -1346,7 +1347,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
 
       lv_obj_t *lbl_q = lv_label_create(box);
       lv_label_set_text(lbl_q, copy_flow_via_list ? T(STR_COPY_CONFIRM_TITLE) : T(STR_CONFIRM_LINK));
-      lv_obj_set_style_text_color(lbl_q, lv_color_hex(0x28d49a), 0);
+      lv_obj_set_style_text_color(lbl_q, tc(TH_ACCENT), 0);
       lv_obj_set_style_text_font(lbl_q, &lv_font_montserrat_ext_18, 0);
       lv_obj_set_style_text_align(lbl_q, LV_TEXT_ALIGN_CENTER, 0);
       lv_obj_align(lbl_q, LV_ALIGN_TOP_MID, 0, 16);
@@ -1364,7 +1365,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
       }
       lv_obj_t *lbl_info = lv_label_create(box);
       lv_label_set_text(lbl_info, info);
-      lv_obj_set_style_text_color(lbl_info, lv_color_hex(0xc8d8f0), 0);
+      lv_obj_set_style_text_color(lbl_info, tc(TH_TEXT), 0);
       lv_obj_set_style_text_font(lbl_info, &lv_font_montserrat_ext_16, 0);
       lv_obj_set_style_text_align(lbl_info, LV_TEXT_ALIGN_CENTER, 0);
       lv_label_set_long_mode(lbl_info, LV_LABEL_LONG_WRAP);
@@ -1375,8 +1376,8 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
       lv_obj_t *btn_yes = lv_btn_create(box);
       lv_obj_set_size(btn_yes, 420, 46);
       lv_obj_set_pos(btn_yes, 10, 110);
-      lv_obj_set_style_bg_color(btn_yes, lv_color_hex(0x1a3020), 0);
-      lv_obj_set_style_bg_color(btn_yes, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+      lv_obj_set_style_bg_color(btn_yes, tc(TH_OK_BG), 0);
+      lv_obj_set_style_bg_color(btn_yes, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
       lv_obj_set_style_radius(btn_yes, 8, 0);
       lv_obj_set_style_shadow_width(btn_yes, 0, 0);
       lv_obj_set_style_border_width(btn_yes, 0, 0);
@@ -1409,7 +1410,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
       }, LV_EVENT_CLICKED, NULL);
       lv_obj_t *lbl_yes = lv_label_create(btn_yes);
       lv_label_set_text(lbl_yes, copy_flow_via_list ? T(STR_BTN_CONFIRMED) : T(STR_LINK_OK));
-      lv_obj_set_style_text_color(lbl_yes, lv_color_hex(0x40c080), 0);
+      lv_obj_set_style_text_color(lbl_yes, tc(TH_SUCCESS_TEXT), 0);
       lv_obj_set_style_text_font(lbl_yes, &lv_font_montserrat_ext_18, 0);
       lv_obj_center(lbl_yes);
 
@@ -1417,8 +1418,8 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
       lv_obj_t *btn_no = lv_btn_create(box);
       lv_obj_set_size(btn_no, 420, 40);
       lv_obj_set_pos(btn_no, 10, 164);
-      lv_obj_set_style_bg_color(btn_no, lv_color_hex(0x3a1010), 0);
-      lv_obj_set_style_bg_color(btn_no, lv_color_hex(0x602020), LV_STATE_PRESSED);
+      lv_obj_set_style_bg_color(btn_no, tc(TH_DANGER_BG), 0);
+      lv_obj_set_style_bg_color(btn_no, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
       lv_obj_set_style_radius(btn_no, 8, 0);
       lv_obj_set_style_shadow_width(btn_no, 0, 0);
       lv_obj_set_style_border_width(btn_no, 0, 0);
@@ -1427,7 +1428,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
       }, LV_EVENT_CLICKED, NULL);
       lv_obj_t *lbl_no = lv_label_create(btn_no);
       lv_label_set_text(lbl_no, T(STR_CANCEL));
-      lv_obj_set_style_text_color(lbl_no, lv_color_hex(0xff8080), 0);
+      lv_obj_set_style_text_color(lbl_no, tc(TH_DANGER_TEXT), 0);
       lv_obj_set_style_text_font(lbl_no, &lv_font_montserrat_ext_14, 0);
       lv_obj_center(lbl_no);
 
@@ -1437,7 +1438,7 @@ void showFilteredSpoolList(const char* vendor_name, const char* material_prefix,
   if (count == 0) {
     lv_obj_t *lbl_empty = lv_label_create(scr_link_spools);
     lv_label_set_text(lbl_empty, T(STR_NO_SPOOLS));
-    lv_obj_set_style_text_color(lbl_empty, lv_color_hex(0xf0b838), 0);
+    lv_obj_set_style_text_color(lbl_empty, tc(TH_WARNING), 0);
     lv_obj_set_style_text_font(lbl_empty, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(lbl_empty, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl_empty, LV_ALIGN_CENTER, 0, -20);
@@ -1465,20 +1466,20 @@ void showMaterialList(const char* vendor_name) {
   // Header with Back + Cancel
   lv_obj_t *hdr_mat = lv_obj_create(scr_link_mat);
   lv_obj_set_size(hdr_mat, 480, 52); lv_obj_set_pos(hdr_mat, 0, 0);
-  lv_obj_set_style_bg_color(hdr_mat, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(hdr_mat, tc(TH_BG), 0);
   lv_obj_set_style_border_width(hdr_mat, 0, 0);
   lv_obj_set_style_pad_all(hdr_mat, 0, 0);
   lv_obj_set_style_radius(hdr_mat, 0, 0);
   lv_obj_clear_flag(hdr_mat, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_t *lbl_title = lv_label_create(hdr_mat);
   lv_label_set_text(lbl_title, title_buf);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(lbl_title, LV_ALIGN_CENTER, 0, 0);
   lv_obj_t *btn_mat_back = lv_btn_create(hdr_mat);
   lv_obj_set_size(btn_mat_back, 44, 44); lv_obj_set_pos(btn_mat_back, 4, 4);
-  lv_obj_set_style_bg_color(btn_mat_back, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_mat_back, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_mat_back, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_mat_back, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_mat_back, 8, 0);
   lv_obj_set_style_shadow_width(btn_mat_back, 0, 0);
   lv_obj_set_style_border_width(btn_mat_back, 0, 0);
@@ -1488,13 +1489,13 @@ void showMaterialList(const char* vendor_name) {
     showVendorList();
   }, LV_EVENT_CLICKED, NULL);
   { lv_obj_t *l = lv_label_create(btn_mat_back); lv_label_set_text(l, LV_SYMBOL_LEFT);
-    lv_obj_set_style_text_color(l, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(l, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_18, 0); lv_obj_center(l); }
   lv_obj_t *btn_mat_cancel = lv_btn_create(hdr_mat);
   lv_obj_set_size(btn_mat_cancel, 44, 44);
   lv_obj_align(btn_mat_cancel, LV_ALIGN_RIGHT_MID, -4, 0);
-  lv_obj_set_style_bg_color(btn_mat_cancel, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_mat_cancel, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_mat_cancel, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_mat_cancel, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_mat_cancel, 8, 0);
   lv_obj_set_style_shadow_width(btn_mat_cancel, 0, 0);
   lv_obj_set_style_border_width(btn_mat_cancel, 0, 0);
@@ -1508,11 +1509,11 @@ void showMaterialList(const char* vendor_name) {
     if (scr_copy_entry)  { lv_obj_del(scr_copy_entry);  scr_copy_entry  = nullptr; }
   }, LV_EVENT_CLICKED, NULL);
   { lv_obj_t *l = lv_label_create(btn_mat_cancel); lv_label_set_text(l, LV_SYMBOL_CLOSE);
-    lv_obj_set_style_text_color(l, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(l, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_18, 0); lv_obj_center(l); }
   lv_obj_t *div = lv_obj_create(scr_link_mat);
   lv_obj_set_size(div, 480, 1); lv_obj_set_pos(div, 0, 52);
-  lv_obj_set_style_bg_color(div, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(div, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(div, 0, 0);
   lv_obj_set_style_radius(div, 0, 0);
   lv_obj_set_style_pad_all(div, 0, 0);
@@ -1520,7 +1521,7 @@ void showMaterialList(const char* vendor_name) {
   lv_obj_t *list = lv_obj_create(scr_link_mat);
   lv_obj_set_size(list, 460, 264);
   lv_obj_set_pos(list, 10, 56);
-  lv_obj_set_style_bg_color(list, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(list, tc(TH_BG), 0);
   lv_obj_set_style_border_width(list, 0, 0);
   lv_obj_set_style_pad_all(list, 2, 0);
   lv_obj_set_style_radius(list, 0, 0);
@@ -1557,24 +1558,24 @@ void showMaterialList(const char* vendor_name) {
   for (int m = 0; m < seen_count; m++) {
     lv_obj_t *row = lv_btn_create(list);
     lv_obj_set_size(row, 452, 50);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE), 0);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE_2), LV_STATE_PRESSED);
     lv_obj_set_style_radius(row, 6, 0);
     lv_obj_set_style_shadow_width(row, 0, 0);
     lv_obj_set_style_border_width(row, 1, 0);
-    lv_obj_set_style_border_color(row, lv_color_hex(0x1a2840), 0);
+    lv_obj_set_style_border_color(row, tc(TH_SURFACE_3), 0);
     lv_obj_set_style_pad_all(row, 0, 0);
 
     lv_obj_t *lbl_mat = lv_label_create(row);
     lv_label_set_text(lbl_mat, seen_mats[m]);
-    lv_obj_set_style_text_color(lbl_mat, lv_color_hex(0xf0b838), 0);
+    lv_obj_set_style_text_color(lbl_mat, tc(TH_WARNING), 0);
     lv_obj_set_style_text_font(lbl_mat, &lv_font_montserrat_ext_18, 0);
     lv_obj_align(lbl_mat, LV_ALIGN_LEFT_MID, 16, 0);
 
     lv_obj_t *lbl_cnt = lv_label_create(row);
     char cnt_buf[12]; snprintf(cnt_buf, sizeof(cnt_buf), "%d x", mat_counts[m]);
     lv_label_set_text(lbl_cnt, cnt_buf);
-    lv_obj_set_style_text_color(lbl_cnt, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl_cnt, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl_cnt, &lv_font_montserrat_ext_16, 0);
     lv_obj_align(lbl_cnt, LV_ALIGN_RIGHT_MID, -16, 0);
 
@@ -1591,7 +1592,7 @@ void showMaterialList(const char* vendor_name) {
   if (seen_count == 0) {
     lv_obj_t *lbl_empty = lv_label_create(scr_link_mat);
     lv_label_set_text(lbl_empty, T(STR_NO_MATERIALS));
-    lv_obj_set_style_text_color(lbl_empty, lv_color_hex(0xf0b838), 0);
+    lv_obj_set_style_text_color(lbl_empty, tc(TH_WARNING), 0);
     lv_obj_set_style_text_font(lbl_empty, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(lbl_empty, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl_empty, LV_ALIGN_CENTER, 0, -20);
@@ -1657,21 +1658,21 @@ void showMaterialSubList(const char* vendor_name, const char* material_prefix) {
   // Header with Back + Cancel
   lv_obj_t *hdr_ms = lv_obj_create(scr_link_mat_sub);
   lv_obj_set_size(hdr_ms, 480, 52); lv_obj_set_pos(hdr_ms, 0, 0);
-  lv_obj_set_style_bg_color(hdr_ms, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(hdr_ms, tc(TH_BG), 0);
   lv_obj_set_style_border_width(hdr_ms, 0, 0);
   lv_obj_set_style_pad_all(hdr_ms, 0, 0);
   lv_obj_set_style_radius(hdr_ms, 0, 0);
   lv_obj_clear_flag(hdr_ms, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_t *lbl_title = lv_label_create(hdr_ms);
   lv_label_set_text(lbl_title, title_buf);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(lbl_title, LV_ALIGN_CENTER, 0, 0);
 
   lv_obj_t *btn_ms_back = lv_btn_create(hdr_ms);
   lv_obj_set_size(btn_ms_back, 44, 44); lv_obj_set_pos(btn_ms_back, 4, 4);
-  lv_obj_set_style_bg_color(btn_ms_back, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_ms_back, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_ms_back, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_ms_back, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_ms_back, 8, 0);
   lv_obj_set_style_shadow_width(btn_ms_back, 0, 0);
   lv_obj_set_style_border_width(btn_ms_back, 0, 0);
@@ -1681,14 +1682,14 @@ void showMaterialSubList(const char* vendor_name, const char* material_prefix) {
     showMaterialList(link_selected_vendor);
   }, LV_EVENT_CLICKED, NULL);
   { lv_obj_t *l = lv_label_create(btn_ms_back); lv_label_set_text(l, LV_SYMBOL_LEFT);
-    lv_obj_set_style_text_color(l, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(l, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_18, 0); lv_obj_center(l); }
 
   lv_obj_t *btn_ms_cancel = lv_btn_create(hdr_ms);
   lv_obj_set_size(btn_ms_cancel, 44, 44);
   lv_obj_align(btn_ms_cancel, LV_ALIGN_RIGHT_MID, -4, 0);
-  lv_obj_set_style_bg_color(btn_ms_cancel, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_ms_cancel, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_ms_cancel, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_ms_cancel, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_ms_cancel, 8, 0);
   lv_obj_set_style_shadow_width(btn_ms_cancel, 0, 0);
   lv_obj_set_style_border_width(btn_ms_cancel, 0, 0);
@@ -1702,12 +1703,12 @@ void showMaterialSubList(const char* vendor_name, const char* material_prefix) {
     if (scr_copy_entry)  { lv_obj_del(scr_copy_entry);  scr_copy_entry  = nullptr; }
   }, LV_EVENT_CLICKED, NULL);
   { lv_obj_t *l = lv_label_create(btn_ms_cancel); lv_label_set_text(l, LV_SYMBOL_CLOSE);
-    lv_obj_set_style_text_color(l, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(l, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_18, 0); lv_obj_center(l); }
 
   lv_obj_t *div = lv_obj_create(scr_link_mat_sub);
   lv_obj_set_size(div, 480, 1); lv_obj_set_pos(div, 0, 52);
-  lv_obj_set_style_bg_color(div, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(div, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(div, 0, 0);
   lv_obj_set_style_radius(div, 0, 0);
   lv_obj_set_style_pad_all(div, 0, 0);
@@ -1715,7 +1716,7 @@ void showMaterialSubList(const char* vendor_name, const char* material_prefix) {
   lv_obj_t *list = lv_obj_create(scr_link_mat_sub);
   lv_obj_set_size(list, 460, 264);
   lv_obj_set_pos(list, 10, 56);
-  lv_obj_set_style_bg_color(list, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(list, tc(TH_BG), 0);
   lv_obj_set_style_border_width(list, 0, 0);
   lv_obj_set_style_pad_all(list, 2, 0);
   lv_obj_set_style_radius(list, 0, 0);
@@ -1725,17 +1726,17 @@ void showMaterialSubList(const char* vendor_name, const char* material_prefix) {
   for (int m = 0; m < full_seen_count; m++) {
     lv_obj_t *row = lv_btn_create(list);
     lv_obj_set_size(row, 452, 50);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE), 0);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE_2), LV_STATE_PRESSED);
     lv_obj_set_style_radius(row, 6, 0);
     lv_obj_set_style_shadow_width(row, 0, 0);
     lv_obj_set_style_border_width(row, 1, 0);
-    lv_obj_set_style_border_color(row, lv_color_hex(0x1a2840), 0);
+    lv_obj_set_style_border_color(row, tc(TH_SURFACE_3), 0);
     lv_obj_set_style_pad_all(row, 0, 0);
 
     lv_obj_t *lbl_full = lv_label_create(row);
     lv_label_set_text(lbl_full, seen_full[m]);
-    lv_obj_set_style_text_color(lbl_full, lv_color_hex(0xf0b838), 0);
+    lv_obj_set_style_text_color(lbl_full, tc(TH_WARNING), 0);
     lv_obj_set_style_text_font(lbl_full, &lv_font_montserrat_ext_18, 0);
     lv_obj_align(lbl_full, LV_ALIGN_LEFT_MID, 16, 0);
     lv_label_set_long_mode(lbl_full, LV_LABEL_LONG_DOT);
@@ -1744,7 +1745,7 @@ void showMaterialSubList(const char* vendor_name, const char* material_prefix) {
     lv_obj_t *lbl_cnt = lv_label_create(row);
     char cnt_buf[12]; snprintf(cnt_buf, sizeof(cnt_buf), "%d x", full_counts[m]);
     lv_label_set_text(lbl_cnt, cnt_buf);
-    lv_obj_set_style_text_color(lbl_cnt, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl_cnt, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl_cnt, &lv_font_montserrat_ext_16, 0);
     lv_obj_align(lbl_cnt, LV_ALIGN_RIGHT_MID, -16, 0);
 
@@ -1760,7 +1761,7 @@ void showMaterialSubList(const char* vendor_name, const char* material_prefix) {
   if (full_seen_count == 0) {
     lv_obj_t *lbl_empty = lv_label_create(scr_link_mat_sub);
     lv_label_set_text(lbl_empty, T(STR_NO_MATERIALS));
-    lv_obj_set_style_text_color(lbl_empty, lv_color_hex(0xf0b838), 0);
+    lv_obj_set_style_text_color(lbl_empty, tc(TH_WARNING), 0);
     lv_obj_set_style_text_font(lbl_empty, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(lbl_empty, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl_empty, LV_ALIGN_CENTER, 0, -20);
@@ -1790,21 +1791,21 @@ void showVendorList() {
 
   lv_obj_t *hdr_vnd = lv_obj_create(scr_link_vendor);
   lv_obj_set_size(hdr_vnd, 480, 52); lv_obj_set_pos(hdr_vnd, 0, 0);
-  lv_obj_set_style_bg_color(hdr_vnd, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(hdr_vnd, tc(TH_BG), 0);
   lv_obj_set_style_border_width(hdr_vnd, 0, 0);
   lv_obj_set_style_pad_all(hdr_vnd, 0, 0);
   lv_obj_set_style_radius(hdr_vnd, 0, 0);
   lv_obj_clear_flag(hdr_vnd, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_t *lbl_title = lv_label_create(hdr_vnd);
   lv_label_set_text(lbl_title, title_buf);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(lbl_title, LV_ALIGN_CENTER, 0, 0);
   // Back: go back to entry popup
   lv_obj_t *btn_vnd_back = lv_btn_create(hdr_vnd);
   lv_obj_set_size(btn_vnd_back, 44, 44); lv_obj_set_pos(btn_vnd_back, 4, 4);
-  lv_obj_set_style_bg_color(btn_vnd_back, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_vnd_back, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_vnd_back, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_vnd_back, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_vnd_back, 8, 0);
   lv_obj_set_style_shadow_width(btn_vnd_back, 0, 0);
   lv_obj_set_style_border_width(btn_vnd_back, 0, 0);
@@ -1815,13 +1816,13 @@ void showVendorList() {
     if (scr_copy_entry)  lv_obj_clear_flag(scr_copy_entry, LV_OBJ_FLAG_HIDDEN);
   }, LV_EVENT_CLICKED, NULL);
   { lv_obj_t *l = lv_label_create(btn_vnd_back); lv_label_set_text(l, LV_SYMBOL_LEFT);
-    lv_obj_set_style_text_color(l, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(l, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_18, 0); lv_obj_center(l); }
   lv_obj_t *btn_vnd_x = lv_btn_create(hdr_vnd);
   lv_obj_set_size(btn_vnd_x, 44, 44);
   lv_obj_align(btn_vnd_x, LV_ALIGN_RIGHT_MID, -4, 0);
-  lv_obj_set_style_bg_color(btn_vnd_x, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_vnd_x, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_vnd_x, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_vnd_x, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_vnd_x, 8, 0);
   lv_obj_set_style_shadow_width(btn_vnd_x, 0, 0);
   lv_obj_set_style_border_width(btn_vnd_x, 0, 0);
@@ -1833,11 +1834,11 @@ void showVendorList() {
     if (scr_copy_entry)  { lv_obj_del(scr_copy_entry);  scr_copy_entry  = nullptr; }
   }, LV_EVENT_CLICKED, NULL);
   { lv_obj_t *l = lv_label_create(btn_vnd_x); lv_label_set_text(l, LV_SYMBOL_CLOSE);
-    lv_obj_set_style_text_color(l, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(l, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_18, 0); lv_obj_center(l); }
   lv_obj_t *div = lv_obj_create(scr_link_vendor);
   lv_obj_set_size(div, 480, 1); lv_obj_set_pos(div, 0, 52);
-  lv_obj_set_style_bg_color(div, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(div, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(div, 0, 0);
   lv_obj_set_style_radius(div, 0, 0);
   lv_obj_set_style_pad_all(div, 0, 0);
@@ -1845,7 +1846,7 @@ void showVendorList() {
   lv_obj_t *list = lv_obj_create(scr_link_vendor);
   lv_obj_set_size(list, 460, 264);
   lv_obj_set_pos(list, 10, 56);
-  lv_obj_set_style_bg_color(list, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(list, tc(TH_BG), 0);
   lv_obj_set_style_border_width(list, 0, 0);
   lv_obj_set_style_pad_all(list, 2, 0);
   lv_obj_set_style_radius(list, 0, 0);
@@ -1880,17 +1881,17 @@ void showVendorList() {
   for (int v = 0; v < seen_v; v++) {
     lv_obj_t *row = lv_btn_create(list);
     lv_obj_set_size(row, 452, 50);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE), 0);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE_2), LV_STATE_PRESSED);
     lv_obj_set_style_radius(row, 6, 0);
     lv_obj_set_style_shadow_width(row, 0, 0);
     lv_obj_set_style_border_width(row, 1, 0);
-    lv_obj_set_style_border_color(row, lv_color_hex(0x1a2840), 0);
+    lv_obj_set_style_border_color(row, tc(TH_SURFACE_3), 0);
     lv_obj_set_style_pad_all(row, 0, 0);
 
     lv_obj_t *lbl_vnd = lv_label_create(row);
     lv_label_set_text(lbl_vnd, seen_vendors[v]);
-    lv_obj_set_style_text_color(lbl_vnd, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl_vnd, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl_vnd, &lv_font_montserrat_ext_18, 0);
     lv_obj_align(lbl_vnd, LV_ALIGN_LEFT_MID, 16, 0);
     lv_label_set_long_mode(lbl_vnd, LV_LABEL_LONG_DOT);
@@ -1899,7 +1900,7 @@ void showVendorList() {
     lv_obj_t *lbl_cnt = lv_label_create(row);
     char cnt_buf[12]; snprintf(cnt_buf, sizeof(cnt_buf), "%d x", vendor_counts[v]);
     lv_label_set_text(lbl_cnt, cnt_buf);
-    lv_obj_set_style_text_color(lbl_cnt, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl_cnt, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl_cnt, &lv_font_montserrat_ext_16, 0);
     lv_obj_align(lbl_cnt, LV_ALIGN_RIGHT_MID, -16, 0);
 
@@ -1913,7 +1914,7 @@ void showVendorList() {
   if (seen_v == 0) {
     lv_obj_t *lbl_empty = lv_label_create(scr_link_vendor);
     { char eb[80]; backendText(T(STR_NO_VENDORS), eb, sizeof(eb)); lv_label_set_text(lbl_empty, eb); }
-    lv_obj_set_style_text_color(lbl_empty, lv_color_hex(0xf0b838), 0);
+    lv_obj_set_style_text_color(lbl_empty, tc(TH_WARNING), 0);
     lv_obj_set_style_text_font(lbl_empty, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(lbl_empty, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl_empty, LV_ALIGN_CENTER, 0, -20);
@@ -1944,7 +1945,7 @@ void showLinkEntryPopup(bool is_bambu) {
   // Header-Titel
   lv_obj_t *lbl_title = lv_label_create(scr_link_entry);
   lv_label_set_text(lbl_title, is_bambu ? T(STR_LINK_BAMBU_TITLE) : T(STR_LINK_NTAG_TITLE));
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
   lv_obj_set_style_text_align(lbl_title, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 22);
@@ -1952,7 +1953,7 @@ void showLinkEntryPopup(bool is_bambu) {
   // Separator line
   lv_obj_t *div = lv_obj_create(scr_link_entry);
   lv_obj_set_size(div, 472, 1); lv_obj_set_pos(div, 4, 52);
-  lv_obj_set_style_bg_color(div, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(div, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(div, 0, 0);
   lv_obj_set_style_radius(div, 0, 0);
   lv_obj_set_style_pad_all(div, 0, 0);
@@ -1968,7 +1969,7 @@ void showLinkEntryPopup(bool is_bambu) {
     snprintf(ctx_buf, sizeof(ctx_buf), "UID: %s", link_tag_uid);
   }
   lv_label_set_text(lbl_ctx, ctx_buf);
-  lv_obj_set_style_text_color(lbl_ctx, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_ctx, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_ctx, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_ctx, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_ctx, LV_LABEL_LONG_WRAP);
@@ -1983,19 +1984,19 @@ void showLinkEntryPopup(bool is_bambu) {
   lv_obj_t *btn1 = lv_btn_create(scr_link_entry);
   lv_obj_set_size(btn1, BTN_W, BTN_H);
   lv_obj_align(btn1, LV_ALIGN_TOP_MID, 0, Y1);
-  lv_obj_set_style_bg_color(btn1, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn1, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn1, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn1, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn1, 10, 0);
   lv_obj_set_style_shadow_width(btn1, 0, 0);
   lv_obj_set_style_border_width(btn1, 1, 0);
-  lv_obj_set_style_border_color(btn1, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn1, tc(TH_SURFACE_2), 0);
   lv_obj_add_event_cb(btn1, [](lv_event_t *e) {
     link_id_input[0] = '\0';
     showIdInputPopup(link_flow_is_bambu);
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *l1 = lv_label_create(btn1);
   lv_label_set_text(l1, T(STR_BTN_ENTER_ID));
-  lv_obj_set_style_text_color(l1, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(l1, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(l1, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(l1);
 
@@ -2003,12 +2004,12 @@ void showLinkEntryPopup(bool is_bambu) {
   lv_obj_t *btn2 = lv_btn_create(scr_link_entry);
   lv_obj_set_size(btn2, BTN_W, BTN_H);
   lv_obj_align(btn2, LV_ALIGN_TOP_MID, 0, Y2);
-  lv_obj_set_style_bg_color(btn2, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn2, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn2, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn2, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn2, 10, 0);
   lv_obj_set_style_shadow_width(btn2, 0, 0);
   lv_obj_set_style_border_width(btn2, 1, 0);
-  lv_obj_set_style_border_color(btn2, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn2, tc(TH_SURFACE_2), 0);
   lv_obj_add_event_cb(btn2, [](lv_event_t *e) {
     // Load and pre-filter spools, then start appropriate flow
     fetchAllSpoolsForLink(link_flow_is_bambu, link_flow_is_bambu ? g_tag.material : "");
@@ -2020,7 +2021,7 @@ void showLinkEntryPopup(bool is_bambu) {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *l2 = lv_label_create(btn2);
   lv_label_set_text(l2, T(STR_BTN_FROM_LIST));
-  lv_obj_set_style_text_color(l2, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(l2, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(l2, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(l2);
 
@@ -2028,8 +2029,8 @@ void showLinkEntryPopup(bool is_bambu) {
   lv_obj_t *btn3 = lv_btn_create(scr_link_entry);
   lv_obj_set_size(btn3, BTN_W, BTN_H - 14);  // etwas kleiner
   lv_obj_align(btn3, LV_ALIGN_TOP_MID, 0, Y3);
-  lv_obj_set_style_bg_color(btn3, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn3, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn3, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn3, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn3, 10, 0);
   lv_obj_set_style_shadow_width(btn3, 0, 0);
   lv_obj_set_style_border_width(btn3, 0, 0);
@@ -2039,7 +2040,7 @@ void showLinkEntryPopup(bool is_bambu) {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *l3 = lv_label_create(btn3);
   lv_label_set_text(l3, T(STR_CANCEL));
-  lv_obj_set_style_text_color(l3, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(l3, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(l3, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(l3);
 }
@@ -2124,12 +2125,12 @@ void doCopySpoolCreate(int template_filament_id, float template_initial, float t
     logSDf("Copy spool created: filament_id=%d new_spool_id=%d", template_filament_id, new_id);
     finishCopyFlow(new_id);
     lv_label_set_text(lbl_status, T(STR_COPY_OK));
-    lv_obj_set_style_text_color(lbl_status, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(lbl_status, tc(TH_ACCENT), 0);
     return;
   }
   Serial.printf("Copy spool POST failed: HTTP %d\n", code);
   lv_label_set_text(lbl_status, T(STR_COPY_FAIL));
-  lv_obj_set_style_text_color(lbl_status, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_status, tc(TH_DANGER_TEXT), 0);
 }
 
 // Confirm popup: shows template name + current scale weight, then creates
@@ -2145,7 +2146,7 @@ void showCopyConfirmPopup(int template_filament_id, const char* template_name,
   scr_copy_confirm = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr_copy_confirm, 480, 320);
   lv_obj_set_pos(scr_copy_confirm, 0, 0);
-  lv_obj_set_style_bg_color(scr_copy_confirm, lv_color_hex(0x000000), 0);
+  lv_obj_set_style_bg_color(scr_copy_confirm, tc(TH_BLACK), 0);
   lv_obj_set_style_bg_opa(scr_copy_confirm, LV_OPA_70, 0);
   lv_obj_set_style_border_width(scr_copy_confirm, 0, 0);
   lv_obj_set_style_pad_all(scr_copy_confirm, 0, 0);
@@ -2155,7 +2156,7 @@ void showCopyConfirmPopup(int template_filament_id, const char* template_name,
   lv_obj_set_size(box, 420, 260);
   lv_obj_align(box, LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_bg_color(box, lv_color_hex(0x0c1828), 0);
-  lv_obj_set_style_border_color(box, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_border_color(box, tc(TH_ACCENT), 0);
   lv_obj_set_style_border_width(box, 1, 0);
   lv_obj_set_style_radius(box, 10, 0);
   lv_obj_set_style_pad_all(box, 0, 0);
@@ -2165,7 +2166,7 @@ void showCopyConfirmPopup(int template_filament_id, const char* template_name,
   lv_obj_t *lbl_title = lv_label_create(box);
   char title_buf[32]; strncpy(title_buf, T(STR_COPY_CONFIRM_TITLE), sizeof(title_buf)-1);
   lv_label_set_text(lbl_title, title_buf);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_title, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 14);
@@ -2177,7 +2178,7 @@ void showCopyConfirmPopup(int template_filament_id, const char* template_name,
   if (display_netto < 0) display_netto = 0;
   snprintf(info_buf, sizeof(info_buf), T(STR_COPY_CONFIRM_MSG), template_name, template_remaining, display_netto);
   lv_label_set_text(lbl_info, info_buf);
-  lv_obj_set_style_text_color(lbl_info, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_info, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_info, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_info, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_info, LV_LABEL_LONG_WRAP);
@@ -2214,8 +2215,8 @@ void showCopyConfirmPopup(int template_filament_id, const char* template_name,
   lv_obj_t *btn_no = lv_btn_create(box);
   lv_obj_set_size(btn_no, 180, 52);
   lv_obj_set_pos(btn_no, 224, 192);
-  lv_obj_set_style_bg_color(btn_no, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_no, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_no, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_no, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_no, 8, 0);
   lv_obj_set_style_shadow_width(btn_no, 0, 0);
   lv_obj_add_event_cb(btn_no, [](lv_event_t *e) {
@@ -2226,7 +2227,7 @@ void showCopyConfirmPopup(int template_filament_id, const char* template_name,
   lv_obj_t *lbl_no = lv_label_create(btn_no);
   char no_buf[32]; strncpy(no_buf, T(STR_CANCEL), sizeof(no_buf)-1);
   lv_label_set_text(lbl_no, no_buf);
-  lv_obj_set_style_text_color(lbl_no, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_no, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_no, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_no, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_no, LV_ALIGN_CENTER, 0, 0);
@@ -2363,7 +2364,7 @@ void showCopySpoolList() {
   scr_copy_list = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr_copy_list, 480, 320);
   lv_obj_set_pos(scr_copy_list, 0, 0);
-  lv_obj_set_style_bg_color(scr_copy_list, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_copy_list, tc(TH_BG), 0);
   lv_obj_set_style_border_width(scr_copy_list, 0, 0);
   lv_obj_set_style_pad_all(scr_copy_list, 0, 0);
   lv_obj_set_style_radius(scr_copy_list, 0, 0);
@@ -2377,7 +2378,7 @@ void showCopySpoolList() {
   lv_obj_t *hdr = lv_obj_create(scr_copy_list);
   lv_obj_set_size(hdr, 480, 52);
   lv_obj_set_pos(hdr, 0, 0);
-  lv_obj_set_style_bg_color(hdr, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(hdr, tc(TH_BG), 0);
   lv_obj_set_style_border_width(hdr, 0, 0);
   lv_obj_set_style_pad_all(hdr, 0, 0);
   lv_obj_set_style_radius(hdr, 0, 0);
@@ -2385,15 +2386,15 @@ void showCopySpoolList() {
 
   lv_obj_t *lbl_title = lv_label_create(hdr);
   lv_label_set_text(lbl_title, title_buf);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(lbl_title, LV_ALIGN_CENTER, 0, 0);
 
   lv_obj_t *btn_hdr_back = lv_btn_create(hdr);
   lv_obj_set_size(btn_hdr_back, 44, 44);
   lv_obj_set_pos(btn_hdr_back, 4, 4);
-  lv_obj_set_style_bg_color(btn_hdr_back, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_hdr_back, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_hdr_back, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_hdr_back, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_hdr_back, 8, 0);
   lv_obj_set_style_shadow_width(btn_hdr_back, 0, 0);
   lv_obj_set_style_border_width(btn_hdr_back, 0, 0);
@@ -2404,15 +2405,15 @@ void showCopySpoolList() {
   }, LV_EVENT_CLICKED, NULL);
   { lv_obj_t *l = lv_label_create(btn_hdr_back);
     lv_label_set_text(l, LV_SYMBOL_LEFT);
-    lv_obj_set_style_text_color(l, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(l, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_18, 0);
     lv_obj_center(l); }
 
   lv_obj_t *btn_hdr_cancel = lv_btn_create(hdr);
   lv_obj_set_size(btn_hdr_cancel, 44, 44);
   lv_obj_align(btn_hdr_cancel, LV_ALIGN_RIGHT_MID, -4, 0);
-  lv_obj_set_style_bg_color(btn_hdr_cancel, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_hdr_cancel, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_hdr_cancel, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_hdr_cancel, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_hdr_cancel, 8, 0);
   lv_obj_set_style_shadow_width(btn_hdr_cancel, 0, 0);
   lv_obj_set_style_border_width(btn_hdr_cancel, 0, 0);
@@ -2423,14 +2424,14 @@ void showCopySpoolList() {
   }, LV_EVENT_CLICKED, NULL);
   { lv_obj_t *l = lv_label_create(btn_hdr_cancel);
     lv_label_set_text(l, LV_SYMBOL_CLOSE);
-    lv_obj_set_style_text_color(l, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(l, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_18, 0);
     lv_obj_center(l); }
 
   // Separator
   lv_obj_t *div = lv_obj_create(scr_copy_list);
   lv_obj_set_size(div, 480, 1); lv_obj_set_pos(div, 0, 52);
-  lv_obj_set_style_bg_color(div, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(div, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(div, 0, 0);
   lv_obj_set_style_radius(div, 0, 0);
   lv_obj_set_style_pad_all(div, 0, 0);
@@ -2439,7 +2440,7 @@ void showCopySpoolList() {
     lv_obj_t *lbl_empty = lv_label_create(scr_copy_list);
     char empty_buf[48]; strncpy(empty_buf, T(STR_COPY_NO_SPOOLS), sizeof(empty_buf)-1);
     lv_label_set_text(lbl_empty, empty_buf);
-    lv_obj_set_style_text_color(lbl_empty, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl_empty, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl_empty, &lv_font_montserrat_ext_16, 0);
     lv_obj_align(lbl_empty, LV_ALIGN_CENTER, 0, 0);
     return;
@@ -2448,7 +2449,7 @@ void showCopySpoolList() {
   lv_obj_t *list = lv_obj_create(scr_copy_list);
   lv_obj_set_size(list, 460, 264);
   lv_obj_set_pos(list, 10, 56);
-  lv_obj_set_style_bg_color(list, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(list, tc(TH_BG), 0);
   lv_obj_set_style_border_width(list, 0, 0);
   lv_obj_set_style_pad_all(list, 2, 0);
   lv_obj_set_style_radius(list, 0, 0);
@@ -2463,18 +2464,18 @@ void showCopySpoolList() {
     UnlinkedSpool &s = link_spools[i];
     lv_obj_t *row = lv_btn_create(list);
     lv_obj_set_size(row, 452, 56);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE), 0);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE_2), LV_STATE_PRESSED);
     lv_obj_set_style_radius(row, 6, 0);
     lv_obj_set_style_shadow_width(row, 0, 0);
     lv_obj_set_style_border_width(row, 1, 0);
-    lv_obj_set_style_border_color(row, lv_color_hex(0x1a2840), 0);
+    lv_obj_set_style_border_color(row, tc(TH_SURFACE_3), 0);
     lv_obj_set_style_pad_all(row, 0, 0);
 
     lv_obj_t *lbl_id = lv_label_create(row);
     char id_buf[10]; snprintf(id_buf, sizeof(id_buf), "%d", s.id);
     lv_label_set_text(lbl_id, id_buf);
-    lv_obj_set_style_text_color(lbl_id, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(lbl_id, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(lbl_id, &lv_font_montserrat_ext_16, 0);
     lv_obj_align(lbl_id, LV_ALIGN_TOP_LEFT, 6, 5);
 
@@ -2489,7 +2490,7 @@ void showCopySpoolList() {
     }
     full_name[sizeof(full_name)-1] = '\0';
     lv_label_set_text(lbl_name, full_name);
-    lv_obj_set_style_text_color(lbl_name, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl_name, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl_name, &lv_font_montserrat_ext_16, 0);
     lv_obj_align(lbl_name, LV_ALIGN_TOP_LEFT, 50, 5);
     lv_label_set_long_mode(lbl_name, LV_LABEL_LONG_DOT);
@@ -2500,7 +2501,7 @@ void showCopySpoolList() {
     lv_obj_align(swatch, LV_ALIGN_BOTTOM_LEFT, 6, -6);
     lv_obj_set_style_radius(swatch, 3, 0);
     lv_obj_set_style_border_width(swatch, 1, 0);
-    lv_obj_set_style_border_color(swatch, lv_color_hex(0x2a4060), 0);
+    lv_obj_set_style_border_color(swatch, tc(TH_TEXT_DIM), 0);
     lv_obj_set_style_pad_all(swatch, 0, 0);
     lv_obj_clear_flag(swatch, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_style_bg_color(swatch, swatchColorFromHex(s.color_hex), 0);
@@ -2510,7 +2511,7 @@ void showCopySpoolList() {
     if (s.remaining <= 0 && s.total > 0) snprintf(rest_buf, sizeof(rest_buf), "%.0fg neu", s.total);
     else snprintf(rest_buf, sizeof(rest_buf), "%.0fg", s.remaining);
     lv_label_set_text(lbl_rest, rest_buf);
-    lv_obj_set_style_text_color(lbl_rest, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl_rest, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl_rest, &lv_font_montserrat_ext_14, 0);
     lv_obj_align(lbl_rest, LV_ALIGN_BOTTOM_LEFT, 26, -5);
 
@@ -2553,7 +2554,7 @@ void showCopyIdInputPopup() {
   scr_copy_id = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr_copy_id, 480, 320);
   lv_obj_set_pos(scr_copy_id, 0, 0);
-  lv_obj_set_style_bg_color(scr_copy_id, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_copy_id, tc(TH_BG), 0);
   lv_obj_set_style_border_width(scr_copy_id, 0, 0);
   lv_obj_set_style_pad_all(scr_copy_id, 0, 0);
   lv_obj_set_style_radius(scr_copy_id, 0, 0);
@@ -2564,21 +2565,21 @@ void showCopyIdInputPopup() {
   lv_obj_t *lbl_title = lv_label_create(scr_copy_id);
   char title_buf[32]; backendText(T(STR_COPY_ID_BTN), title_buf, sizeof(title_buf));
   lv_label_set_text(lbl_title, title_buf);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 8);
 
   // Digit display
   lbl_copy_id_display = lv_label_create(scr_copy_id);
   lv_label_set_text(lbl_copy_id_display, "_");
-  lv_obj_set_style_text_color(lbl_copy_id_display, lv_color_hex(0xe8f0ff), 0);
+  lv_obj_set_style_text_color(lbl_copy_id_display, tc(TH_TEXT_BRIGHT), 0);
   lv_obj_set_style_text_font(lbl_copy_id_display, &lv_font_montserrat_ext_24, 0);
   lv_obj_align(lbl_copy_id_display, LV_ALIGN_TOP_MID, 0, 36);
 
   // Status label
   lbl_copy_id_status = lv_label_create(scr_copy_id);
   lv_label_set_text(lbl_copy_id_status, "");
-  lv_obj_set_style_text_color(lbl_copy_id_status, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_copy_id_status, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_copy_id_status, &lv_font_montserrat_ext_12, 0);
   lv_obj_align(lbl_copy_id_status, LV_ALIGN_TOP_MID, 0, 66);
 
@@ -2594,13 +2595,13 @@ void showCopyIdInputPopup() {
     lv_obj_set_pos(btn, NP_X0 + col*(NP_W+NP_GAP), NP_Y0 + row*(NP_H+NP_GAP));
     bool is_ok  = (k == 11);
     bool is_del = (k == 9);
-    lv_obj_set_style_bg_color(btn, is_ok ? lv_color_hex(0x1a3020) : (is_del ? lv_color_hex(0x1a2030) : lv_color_hex(0x0a1828)), 0);
+    lv_obj_set_style_bg_color(btn, is_ok ? tc(TH_OK_BG) : (is_del ? tc(TH_SURFACE_DARK) : tc(TH_SURFACE)), 0);
     lv_obj_set_style_radius(btn, 6, 0);
     lv_obj_set_style_shadow_width(btn, 0, 0);
     lv_obj_set_style_border_width(btn, 0, 0);
     lv_obj_t *lbl = lv_label_create(btn);
     lv_label_set_text(lbl, keys[k]);
-    lv_obj_set_style_text_color(lbl, is_ok ? lv_color_hex(0x40c080) : lv_color_hex(0xc8d8f0), 0);
+    lv_obj_set_style_text_color(lbl, is_ok ? tc(TH_SUCCESS_TEXT) : tc(TH_TEXT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl, LV_ALIGN_CENTER, 0, 0);
@@ -2659,7 +2660,7 @@ void showCopyEntryPopup() {
   scr_copy_entry = lv_obj_create(lv_scr_act());
   lv_obj_set_size(scr_copy_entry, 480, 320);
   lv_obj_set_pos(scr_copy_entry, 0, 0);
-  lv_obj_set_style_bg_color(scr_copy_entry, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_copy_entry, tc(TH_BG), 0);
   lv_obj_set_style_border_width(scr_copy_entry, 0, 0);
   lv_obj_set_style_pad_all(scr_copy_entry, 0, 0);
   lv_obj_set_style_radius(scr_copy_entry, 0, 0);
@@ -2669,7 +2670,7 @@ void showCopyEntryPopup() {
   lv_obj_t *lbl_title = lv_label_create(scr_copy_entry);
   char title_buf[32]; strncpy(title_buf, T(STR_COPY_TITLE), sizeof(title_buf)-1);
   lv_label_set_text(lbl_title, title_buf);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
   lv_obj_set_style_text_align(lbl_title, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 22);
@@ -2677,7 +2678,7 @@ void showCopyEntryPopup() {
   // Separator
   lv_obj_t *div = lv_obj_create(scr_copy_entry);
   lv_obj_set_size(div, 472, 1); lv_obj_set_pos(div, 4, 52);
-  lv_obj_set_style_bg_color(div, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_bg_color(div, tc(TH_SURFACE_2), 0);
   lv_obj_set_style_border_width(div, 0, 0);
   lv_obj_set_style_radius(div, 0, 0);
   lv_obj_set_style_pad_all(div, 0, 0);
@@ -2694,7 +2695,7 @@ void showCopyEntryPopup() {
     snprintf(ctx_buf, sizeof(ctx_buf), "UID: %s", g_tag.uid_str);
   }
   lv_label_set_text(lbl_ctx, ctx_buf);
-  lv_obj_set_style_text_color(lbl_ctx, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_ctx, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_ctx, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_ctx, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_ctx, LV_LABEL_LONG_WRAP);
@@ -2709,17 +2710,17 @@ void showCopyEntryPopup() {
   lv_obj_t *btn1 = lv_btn_create(scr_copy_entry);
   lv_obj_set_size(btn1, BTN_W, BTN_H);
   lv_obj_align(btn1, LV_ALIGN_TOP_MID, 0, Y1);
-  lv_obj_set_style_bg_color(btn1, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn1, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn1, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn1, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn1, 10, 0);
   lv_obj_set_style_shadow_width(btn1, 0, 0);
   lv_obj_set_style_border_width(btn1, 1, 0);
-  lv_obj_set_style_border_color(btn1, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn1, tc(TH_SURFACE_2), 0);
   lv_obj_add_event_cb(btn1, [](lv_event_t *e) { link_id_input[0] = '\0'; showIdInputPopup(strlen(g_tag.tray_uuid) == 32, true); }, LV_EVENT_CLICKED, NULL);
   { lv_obj_t *l = lv_label_create(btn1);
     char b[40]; backendText(T(STR_COPY_ID_BTN), b, sizeof(b));
     lv_label_set_text(l, b);
-    lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
+    lv_obj_set_style_text_color(l, tc(TH_TEXT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(l, LV_ALIGN_CENTER, 0, 0); }
@@ -2728,12 +2729,12 @@ void showCopyEntryPopup() {
   lv_obj_t *btn2 = lv_btn_create(scr_copy_entry);
   lv_obj_set_size(btn2, BTN_W, BTN_H);
   lv_obj_align(btn2, LV_ALIGN_TOP_MID, 0, Y2);
-  lv_obj_set_style_bg_color(btn2, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn2, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn2, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn2, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn2, 10, 0);
   lv_obj_set_style_shadow_width(btn2, 0, 0);
   lv_obj_set_style_border_width(btn2, 1, 0);
-  lv_obj_set_style_border_color(btn2, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn2, tc(TH_SURFACE_2), 0);
   lv_obj_add_event_cb(btn2, [](lv_event_t *e) {
     logSD("BTN: CopyEntry -> Active spools");
     copy_flow_archived = false;
@@ -2756,7 +2757,7 @@ void showCopyEntryPopup() {
   { lv_obj_t *l = lv_label_create(btn2);
     char b[40]; strncpy(b, T(STR_COPY_ACTIVE_BTN), sizeof(b)-1);
     lv_label_set_text(l, b);
-    lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
+    lv_obj_set_style_text_color(l, tc(TH_TEXT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(l, LV_ALIGN_CENTER, 0, 0); }
@@ -2765,12 +2766,12 @@ void showCopyEntryPopup() {
   lv_obj_t *btn3 = lv_btn_create(scr_copy_entry);
   lv_obj_set_size(btn3, BTN_W, BTN_H);
   lv_obj_align(btn3, LV_ALIGN_TOP_MID, 0, Y3);
-  lv_obj_set_style_bg_color(btn3, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn3, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn3, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn3, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn3, 10, 0);
   lv_obj_set_style_shadow_width(btn3, 0, 0);
   lv_obj_set_style_border_width(btn3, 1, 0);
-  lv_obj_set_style_border_color(btn3, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn3, tc(TH_SURFACE_2), 0);
   lv_obj_add_event_cb(btn3, [](lv_event_t *e) {
     logSD("BTN: CopyEntry -> Archived spools");
     copy_flow_archived = true;
@@ -2792,7 +2793,7 @@ void showCopyEntryPopup() {
   { lv_obj_t *l = lv_label_create(btn3);
     char b[40]; strncpy(b, T(STR_COPY_ARCHIVED_BTN), sizeof(b)-1);
     lv_label_set_text(l, b);
-    lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
+    lv_obj_set_style_text_color(l, tc(TH_TEXT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(l, LV_ALIGN_CENTER, 0, 0); }
@@ -2801,8 +2802,8 @@ void showCopyEntryPopup() {
   lv_obj_t *btn4 = lv_btn_create(scr_copy_entry);
   lv_obj_set_size(btn4, BTN_W, BTN_H);
   lv_obj_align(btn4, LV_ALIGN_TOP_MID, 0, Y4);
-  lv_obj_set_style_bg_color(btn4, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn4, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn4, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn4, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn4, 10, 0);
   lv_obj_set_style_shadow_width(btn4, 0, 0);
   lv_obj_set_style_border_width(btn4, 0, 0);
@@ -2810,7 +2811,7 @@ void showCopyEntryPopup() {
   { lv_obj_t *l = lv_label_create(btn4);
     char b[16]; strncpy(b, T(STR_CANCEL), sizeof(b)-1);
     lv_label_set_text(l, b);
-    lv_obj_set_style_text_color(l, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(l, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(l, LV_ALIGN_CENTER, 0, 0); }

--- a/src/ui/spoolman_lookup.cpp
+++ b/src/ui/spoolman_lookup.cpp
@@ -17,6 +17,7 @@
 #include "ui/date_display.h"
 #include "ui/main_screen_helpers.h"
 #include "ui_common.h"
+#include "theme.h"
 
 namespace {
 
@@ -231,8 +232,8 @@ void querySpoolmanById(int spool_id) {
   float pct = (sm_total > 0) ? (sm_remaining / sm_total) * 100.0f : 0;
   uint32_t pct_color;
   if (pct <= 10.0f)      pct_color = 0xe04040;
-  else if (pct <= 30.0f) pct_color = 0xf0b838;
-  else                   pct_color = 0x28d49a;
+  else if (pct <= 30.0f) pct_color = g_theme[TH_WARNING];
+  else                   pct_color = g_theme[TH_ACCENT];
   lv_obj_set_style_text_color(lbl_spoolman_weight, lv_color_hex(pct_color), 0);
 
   char pct_str[16];
@@ -251,7 +252,7 @@ void querySpoolmanById(int spool_id) {
   char sm_id_str[16];
   snprintf(sm_id_str, sizeof(sm_id_str), "%d", sm_id);
   lv_label_set_text(lbl_spoolman_id, sm_id_str);
-  lv_obj_set_style_text_color(lbl_spoolman_id, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_spoolman_id, tc(TH_ACCENT), 0);
 
   char dried_display[48];
   driedDisplayStr(sm_last_dried, dried_display, sizeof(dried_display));
@@ -276,7 +277,7 @@ void querySpoolman(const char* tray_uuid) {
 
   // Reset all Spoolman labels before new query
   lv_label_set_text(lbl_spoolman_weight, T(STR_WAIT));
-  lv_obj_set_style_text_color(lbl_spoolman_weight, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_spoolman_weight, tc(TH_ACCENT), 0);
   lv_label_set_text(lbl_spoolman_pct, "");
   lv_label_set_text(lbl_spoolman_dried_val, "");
   if (lbl_dried_sym) lv_obj_add_flag(lbl_dried_sym, LV_OBJ_FLAG_HIDDEN);
@@ -536,8 +537,8 @@ void querySpoolman(const char* tray_uuid) {
     // Choose color: 0-10% red, 11-30% orange, 31-100% green
     uint32_t pct_color;
     if (pct <= 10.0f)       pct_color = 0xe04040;
-    else if (pct <= 30.0f)  pct_color = 0xf0b838;
-    else                    pct_color = 0x28d49a;
+    else if (pct <= 30.0f)  pct_color = g_theme[TH_WARNING];
+    else                    pct_color = g_theme[TH_ACCENT];
 
     lv_obj_set_style_text_color(lbl_spoolman_weight, lv_color_hex(pct_color), 0);
 
@@ -559,7 +560,7 @@ void querySpoolman(const char* tray_uuid) {
     char sm_id_str[16];
     snprintf(sm_id_str, sizeof(sm_id_str), "%d", sm_id);
     lv_label_set_text(lbl_spoolman_id, sm_id_str);
-    lv_obj_set_style_text_color(lbl_spoolman_id, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(lbl_spoolman_id, tc(TH_ACCENT), 0);
 
     // Last drying: set value with "N days ago"
     char dried_display[48];
@@ -632,7 +633,7 @@ void querySpoolman(const char* tray_uuid) {
   Serial.println("Spoolman: spool not found");
   logSD("Spoolman: spool not found");
   { char nb[40]; backendText(T(STR_NOT_IN_SPOOLMAN), nb, sizeof(nb)); lv_label_set_text(lbl_spoolman_weight, nb); }
-  lv_obj_set_style_text_color(lbl_spoolman_weight, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_spoolman_weight, tc(TH_ACCENT), 0);
   sm_found = false;
   updateLinkButton();
 }

--- a/src/ui/spoolman_screen.cpp
+++ b/src/ui/spoolman_screen.cpp
@@ -17,6 +17,7 @@
 #include "header_status.h"
 #include "lang.h"
 #include "ui_common.h"
+#include "theme.h"
 
 
 
@@ -47,7 +48,7 @@ void buildSpoolmanScreen() {
   lv_obj_set_style_border_width(scr_spoolman, 0, 0);
   lv_obj_set_style_pad_all(scr_spoolman, 0, 0);
   lv_obj_clear_flag(scr_spoolman, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr_spoolman, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_spoolman, tc(TH_BG), 0);
 
   // Header. The product name is not translated, so it is composed here
   // instead of living in lang.cpp twice.
@@ -70,7 +71,7 @@ void buildSpoolmanScreen() {
            backendIsFilaMan() ? "8002" : "7912");
   lv_obj_t *lbl_hint = lv_label_create(scr_spoolman);
   lv_label_set_text(lbl_hint, buf_hint);
-  lv_obj_set_style_text_color(lbl_hint, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_hint, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_hint, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_hint, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_hint, LV_ALIGN_TOP_MID, 0, 52);
@@ -86,8 +87,8 @@ void buildSpoolmanScreen() {
   lv_obj_t *input_box = lv_obj_create(scr_spoolman);
   lv_obj_set_size(input_box, 420, 34);
   lv_obj_align(input_box, LV_ALIGN_TOP_MID, 0, 68);
-  lv_obj_set_style_bg_color(input_box, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_border_color(input_box, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_bg_color(input_box, tc(TH_SURFACE), 0);
+  lv_obj_set_style_border_color(input_box, tc(TH_ACCENT), 0);
   lv_obj_set_style_border_width(input_box, 1, 0);
   lv_obj_set_style_radius(input_box, 6, 0);
   lv_obj_set_style_pad_all(input_box, 0, 0);
@@ -95,7 +96,7 @@ void buildSpoolmanScreen() {
 
   lbl_sp_ip_display = lv_label_create(input_box);
   lv_label_set_text(lbl_sp_ip_display, sp_ip_input[0] ? sp_ip_input : "_");
-  lv_obj_set_style_text_color(lbl_sp_ip_display, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_sp_ip_display, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_sp_ip_display, &lv_font_montserrat_ext_18, 0);
   lv_obj_set_style_text_align(lbl_sp_ip_display, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_center(lbl_sp_ip_display);
@@ -121,16 +122,16 @@ void buildSpoolmanScreen() {
     lv_obj_t *btn = lv_btn_create(scr_spoolman);
     lv_obj_set_size(btn, NP_W, NP_H);
     lv_obj_set_pos(btn, bx, by);
-    lv_obj_set_style_bg_color(btn, lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_bg_color(btn, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn, tc(TH_SURFACE), 0);
+    lv_obj_set_style_bg_color(btn, tc(TH_SURFACE_2), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn, 6, 0);
     lv_obj_set_style_shadow_width(btn, 0, 0);
     lv_obj_set_style_border_width(btn, 1, 0);
-    lv_obj_set_style_border_color(btn, lv_color_hex(0x1a2840), 0);
+    lv_obj_set_style_border_color(btn, tc(TH_SURFACE_3), 0);
 
     lv_obj_t *lbl = lv_label_create(btn);
     lv_label_set_text(lbl, np_labels[i]);
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_18, 0);
     lv_obj_center(lbl);
 
@@ -152,12 +153,12 @@ void buildSpoolmanScreen() {
   lv_obj_t *btn_del = lv_btn_create(scr_spoolman);
   lv_obj_set_size(btn_del, bw5, NP_H);
   lv_obj_set_pos(btn_del, NP_PAD_X, by5);
-  lv_obj_set_style_bg_color(btn_del, lv_color_hex(0x1a2030), 0);
+  lv_obj_set_style_bg_color(btn_del, tc(TH_SURFACE_DARK), 0);
   lv_obj_set_style_bg_color(btn_del, lv_color_hex(0x2a3040), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_del, 6, 0);
   lv_obj_set_style_shadow_width(btn_del, 0, 0);
   lv_obj_set_style_border_width(btn_del, 1, 0);
-  lv_obj_set_style_border_color(btn_del, lv_color_hex(0x1a2840), 0);
+  lv_obj_set_style_border_color(btn_del, tc(TH_SURFACE_3), 0);
   lv_obj_add_event_cb(btn_del, [](lv_event_t *e) {
     int len = strlen(sp_ip_input);
     if (len > 0) sp_ip_input[len-1] = '\0';
@@ -165,7 +166,7 @@ void buildSpoolmanScreen() {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_del = lv_label_create(btn_del);
   lv_label_set_text(lbl_del, LV_SYMBOL_BACKSPACE);
-  lv_obj_set_style_text_color(lbl_del, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_del, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_del, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_del);
 
@@ -173,12 +174,12 @@ void buildSpoolmanScreen() {
   lv_obj_t *btn_ok = lv_btn_create(scr_spoolman);
   lv_obj_set_size(btn_ok, bw5, NP_H);
   lv_obj_set_pos(btn_ok, NP_PAD_X + bw5 + NP_GAP, by5);
-  lv_obj_set_style_bg_color(btn_ok, lv_color_hex(0x1a3020), 0);
-  lv_obj_set_style_bg_color(btn_ok, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_ok, tc(TH_OK_BG), 0);
+  lv_obj_set_style_bg_color(btn_ok, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_ok, 6, 0);
   lv_obj_set_style_shadow_width(btn_ok, 0, 0);
   lv_obj_set_style_border_width(btn_ok, 1, 0);
-  lv_obj_set_style_border_color(btn_ok, lv_color_hex(0x2a5030), 0);
+  lv_obj_set_style_border_color(btn_ok, tc(TH_SUCCESS_BG), 0);
   lv_obj_add_event_cb(btn_ok, [](lv_event_t *e) {
     if (!sp_ip_input[0]) return;
     backendSetHost(sp_ip_input);
@@ -186,7 +187,7 @@ void buildSpoolmanScreen() {
     // Show testing status
     if (lbl_sp_test_result) {
       lv_label_set_text(lbl_sp_test_result, "Connecting...");
-      lv_obj_set_style_text_color(lbl_sp_test_result, lv_color_hex(0x4a6fa0), 0);
+      lv_obj_set_style_text_color(lbl_sp_test_result, tc(TH_TEXT_MUTED), 0);
     }
     if (btn_sp_extra_fields) lv_obj_add_flag(btn_sp_extra_fields, LV_OBJ_FLAG_HIDDEN);
     lv_timer_handler();
@@ -200,7 +201,7 @@ void buildSpoolmanScreen() {
         char buf[48];
         snprintf(buf, sizeof(buf), "Error: HTTP %d", hcode);
         lv_label_set_text(lbl_sp_test_result, buf);
-        lv_obj_set_style_text_color(lbl_sp_test_result, lv_color_hex(0xff8080), 0);
+        lv_obj_set_style_text_color(lbl_sp_test_result, tc(TH_DANGER_TEXT), 0);
       }
       logSDf("Spoolman IP test FAIL: HTTP %d ip=%s", hcode, sp_ip_input);
       Serial.printf("Spoolman IP test FAIL: HTTP %d ip=%s\n", hcode, sp_ip_input);
@@ -228,7 +229,7 @@ void buildSpoolmanScreen() {
     }
     if (lbl_sp_test_result) {
       lv_label_set_text(lbl_sp_test_result, result_buf);
-      lv_obj_set_style_text_color(lbl_sp_test_result, lv_color_hex(0x40c080), 0);
+      lv_obj_set_style_text_color(lbl_sp_test_result, tc(TH_SUCCESS_TEXT), 0);
     }
     // Reveal the button again. In FilaMan it only leads somewhere during the
     // setup, where it is the step to the credentials.
@@ -242,7 +243,7 @@ void buildSpoolmanScreen() {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_ok = lv_label_create(btn_ok);
   lv_label_set_text(lbl_ok, T(STR_BTN_SAVE));
-  lv_obj_set_style_text_color(lbl_ok, lv_color_hex(0x40c080), 0);
+  lv_obj_set_style_text_color(lbl_ok, tc(TH_SUCCESS_TEXT), 0);
   lv_obj_set_style_text_font(lbl_ok, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_ok);
 
@@ -254,7 +255,7 @@ void buildSpoolmanScreen() {
   // Test result label — left side, y=281
   lbl_sp_test_result = lv_label_create(scr_spoolman);
   lv_label_set_text(lbl_sp_test_result, "");
-  lv_obj_set_style_text_color(lbl_sp_test_result, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_sp_test_result, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_sp_test_result, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_sp_test_result, LV_TEXT_ALIGN_LEFT, 0);
   lv_obj_set_size(lbl_sp_test_result, 260, BOT_H);
@@ -264,12 +265,12 @@ void buildSpoolmanScreen() {
   btn_sp_extra_fields = lv_btn_create(scr_spoolman);
   lv_obj_set_size(btn_sp_extra_fields, 170, BOT_H);
   lv_obj_set_pos(btn_sp_extra_fields, 480 - NP_PAD_X - 170, BOT_Y);
-  lv_obj_set_style_bg_color(btn_sp_extra_fields, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn_sp_extra_fields, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_sp_extra_fields, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn_sp_extra_fields, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_sp_extra_fields, 8, 0);
   lv_obj_set_style_shadow_width(btn_sp_extra_fields, 0, 0);
   lv_obj_set_style_border_width(btn_sp_extra_fields, 1, 0);
-  lv_obj_set_style_border_color(btn_sp_extra_fields, lv_color_hex(0x1a3060), 0);
+  lv_obj_set_style_border_color(btn_sp_extra_fields, tc(TH_SURFACE_2), 0);
   // This button doubles as the step onward during setup, which is why it
   // starts hidden there and only appears once the connection test passed.
   // FilaMan needs no extra fields at all, it accepts custom_fields keys
@@ -290,7 +291,7 @@ void buildSpoolmanScreen() {
     if (backendIsFilaMan()) snprintf(ef_buf, sizeof(ef_buf), "%s  " LV_SYMBOL_RIGHT, T(STR_BTN_NEXT));
     else                    snprintf(ef_buf, sizeof(ef_buf), "Extra Fields  " LV_SYMBOL_RIGHT);
     lv_label_set_text(lbl_ef, ef_buf); }
-  lv_obj_set_style_text_color(lbl_ef, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_ef, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_ef, &lv_font_montserrat_ext_14, 0);
   lv_obj_align(lbl_ef, LV_ALIGN_CENTER, 0, 0);
 }
@@ -319,12 +320,12 @@ void showSpoolmanFailScreen(bool is_setup_flow) {
   lv_obj_set_style_border_width(scr_spoolman_fail, 0, 0);
   lv_obj_set_style_pad_all(scr_spoolman_fail, 0, 0);
   lv_obj_clear_flag(scr_spoolman_fail, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr_spoolman_fail, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_spoolman_fail, tc(TH_BG), 0);
 
   // Title
   lv_obj_t *lbl_title = lv_label_create(scr_spoolman_fail);
   lv_label_set_text(lbl_title, buf_title);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 20);
 
@@ -339,7 +340,7 @@ void showSpoolmanFailScreen(bool is_setup_flow) {
   // Warning icon
   lv_obj_t *lbl_icon = lv_label_create(scr_spoolman_fail);
   lv_label_set_text(lbl_icon, LV_SYMBOL_WARNING);
-  lv_obj_set_style_text_color(lbl_icon, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_icon, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_icon, &lv_font_montserrat_ext_24, 0);
   lv_obj_align(lbl_icon, LV_ALIGN_TOP_MID, 0, 60);
 
@@ -348,7 +349,7 @@ void showSpoolmanFailScreen(bool is_setup_flow) {
   snprintf(ip_buf, sizeof(ip_buf), "http://%s", cfg_spoolman_ip);
   lv_obj_t *lbl_ip = lv_label_create(scr_spoolman_fail);
   lv_label_set_text(lbl_ip, ip_buf);
-  lv_obj_set_style_text_color(lbl_ip, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_ip, tc(TH_WARNING), 0);
   lv_obj_set_style_text_font(lbl_ip, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_style_text_align(lbl_ip, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_ip, LV_LABEL_LONG_DOT);
@@ -358,7 +359,7 @@ void showSpoolmanFailScreen(bool is_setup_flow) {
   // Error message (from RAM buffer)
   lv_obj_t *lbl_msg = lv_label_create(scr_spoolman_fail);
   lv_label_set_text(lbl_msg, buf_msg);
-  lv_obj_set_style_text_color(lbl_msg, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_msg, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_msg, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_style_text_align(lbl_msg, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(lbl_msg, LV_LABEL_LONG_WRAP);
@@ -369,8 +370,8 @@ void showSpoolmanFailScreen(bool is_setup_flow) {
   lv_obj_t *btn_retry = lv_btn_create(scr_spoolman_fail);
   lv_obj_set_size(btn_retry, 210, 50);
   lv_obj_set_pos(btn_retry, 16, 248);
-  lv_obj_set_style_bg_color(btn_retry, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_retry, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_retry, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_retry, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_retry, 8, 0);
   lv_obj_set_style_shadow_width(btn_retry, 0, 0);
   lv_obj_set_style_border_width(btn_retry, 0, 0);
@@ -380,7 +381,7 @@ void showSpoolmanFailScreen(bool is_setup_flow) {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_r = lv_label_create(btn_retry);
   lv_label_set_text(lbl_r, buf_retry);
-  lv_obj_set_style_text_color(lbl_r, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_r, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_r, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_r);
 
@@ -388,7 +389,7 @@ void showSpoolmanFailScreen(bool is_setup_flow) {
   lv_obj_t *btn_cont = lv_btn_create(scr_spoolman_fail);
   lv_obj_set_size(btn_cont, 210, 50);
   lv_obj_set_pos(btn_cont, 254, 248);
-  lv_obj_set_style_bg_color(btn_cont, lv_color_hex(0x1a2030), 0);
+  lv_obj_set_style_bg_color(btn_cont, tc(TH_SURFACE_DARK), 0);
   lv_obj_set_style_bg_color(btn_cont, lv_color_hex(0x2a3040), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_cont, 8, 0);
   lv_obj_set_style_shadow_width(btn_cont, 0, 0);
@@ -406,7 +407,7 @@ void showSpoolmanFailScreen(bool is_setup_flow) {
   }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_c = lv_label_create(btn_cont);
   lv_label_set_text(lbl_c, buf_skip);
-  lv_obj_set_style_text_color(lbl_c, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_c, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_c, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_c);
 }

--- a/src/ui/system_screen.cpp
+++ b/src/ui/system_screen.cpp
@@ -14,6 +14,7 @@
 #include "ui_common.h"
 #include "update_badges.h"
 #include "services/backend.h"
+#include "theme.h"
 
 
 void showLanguageScreen();
@@ -41,18 +42,18 @@ void buildSystemScreen() {
   lv_obj_set_style_border_color(btn_lang, lv_color_hex(0x1a2a40), 0);
   { lv_obj_t *ico = lv_label_create(btn_lang);
     lv_label_set_text(ico, LV_SYMBOL_LIST);
-    lv_obj_set_style_text_color(ico, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(ico, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(ico, &lv_font_montserrat_ext_24, 0);
     lv_obj_align(ico, LV_ALIGN_CENTER, 0, -18);
     lv_obj_t *lbl = lv_label_create(btn_lang);
     lv_label_set_text(lbl, T(STR_LANG_TITLE));
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl, LV_ALIGN_CENTER, 0, 4);
     lv_obj_t *sub = lv_label_create(btn_lang);
     lv_label_set_text(sub, T(STR_BTN_LANG_SUB));
-    lv_obj_set_style_text_color(sub, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(sub, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(sub, &lv_font_montserrat_ext_12, 0);
     lv_obj_set_style_text_align(sub, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(sub, LV_ALIGN_CENTER, 0, 22); }
@@ -70,18 +71,18 @@ void buildSystemScreen() {
   lv_obj_set_style_border_color(btn_upd, lv_color_hex(0x1a2a40), 0);
   { lv_obj_t *ico = lv_label_create(btn_upd);
     lv_label_set_text(ico, LV_SYMBOL_DOWNLOAD);
-    lv_obj_set_style_text_color(ico, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(ico, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(ico, &lv_font_montserrat_ext_24, 0);
     lv_obj_align(ico, LV_ALIGN_CENTER, 0, -18);
     lv_obj_t *lbl = lv_label_create(btn_upd);
     lv_label_set_text(lbl, T(STR_BTN_FW_UPDATE));
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl, LV_ALIGN_CENTER, 0, 4);
     lv_obj_t *sub = lv_label_create(btn_upd);
     lv_label_set_text(sub, T(STR_BTN_FW_SUB));
-    lv_obj_set_style_text_color(sub, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(sub, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(sub, &lv_font_montserrat_ext_12, 0);
     lv_obj_set_style_text_align(sub, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(sub, LV_ALIGN_CENTER, 0, 22); }
@@ -93,26 +94,26 @@ void buildSystemScreen() {
   lv_obj_t *btn_info = lv_btn_create(scr_system);
   lv_obj_set_size(btn_info, BTN_W, BTN_H);
   lv_obj_set_pos(btn_info, BTN_X, BTN_Y0 + 2*(BTN_H + BTN_GAP));
-  lv_obj_set_style_bg_color(btn_info, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn_info, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_info, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn_info, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_info, 10, 0);
   lv_obj_set_style_shadow_width(btn_info, 0, 0);
   lv_obj_set_style_border_width(btn_info, 1, 0);
-  lv_obj_set_style_border_color(btn_info, lv_color_hex(0x1a3050), 0);
+  lv_obj_set_style_border_color(btn_info, tc(TH_BORDER), 0);
   { lv_obj_t *ico = lv_label_create(btn_info);
     lv_label_set_text(ico, LV_SYMBOL_BELL);
-    lv_obj_set_style_text_color(ico, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(ico, tc(TH_ACCENT), 0);
     lv_obj_set_style_text_font(ico, &lv_font_montserrat_ext_24, 0);
     lv_obj_align(ico, LV_ALIGN_CENTER, 0, -18);
     lv_obj_t *lbl = lv_label_create(btn_info);
     lv_label_set_text(lbl, T(STR_BTN_INFO));
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_16, 0);
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl, LV_ALIGN_CENTER, 0, 4);
     lv_obj_t *sub = lv_label_create(btn_info);
     lv_label_set_text(sub, T(STR_BTN_INFO_SUB));
-    lv_obj_set_style_text_color(sub, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(sub, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(sub, &lv_font_montserrat_ext_12, 0);
     lv_obj_set_style_text_align(sub, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(sub, LV_ALIGN_CENTER, 0, 22); }
@@ -130,7 +131,7 @@ void buildSystemScreen() {
   lv_obj_set_style_radius(btn_reset, 8, 0);
   lv_obj_set_style_shadow_width(btn_reset, 0, 0);
   lv_obj_set_style_border_width(btn_reset, 2, 0);
-  lv_obj_set_style_border_color(btn_reset, lv_color_hex(0x3a1010), 0);
+  lv_obj_set_style_border_color(btn_reset, tc(TH_DANGER_BG), 0);
   { lv_obj_t *lbl = lv_label_create(btn_reset);
     char buf[32]; strncpy(buf, T(STR_BTN_FACTORY_RESET), sizeof(buf)-1);
     lv_label_set_text(lbl, buf);
@@ -150,7 +151,7 @@ void buildSystemScreen() {
     lv_obj_t *pop = lv_obj_create(lv_scr_act());
     lv_obj_set_size(pop, 480, 320);
     lv_obj_set_pos(pop, 0, 0);
-    lv_obj_set_style_bg_color(pop, lv_color_hex(0x000000), 0);
+    lv_obj_set_style_bg_color(pop, tc(TH_BLACK), 0);
     lv_obj_set_style_bg_opa(pop, LV_OPA_80, 0);
     lv_obj_set_style_border_width(pop, 0, 0);
     lv_obj_set_style_radius(pop, 0, 0);
@@ -161,7 +162,7 @@ void buildSystemScreen() {
     lv_obj_set_size(box, 440, 240);
     lv_obj_align(box, LV_ALIGN_CENTER, 0, 0);
     lv_obj_set_style_bg_color(box, lv_color_hex(0x1a0808), 0);
-    lv_obj_set_style_border_color(box, lv_color_hex(0x602020), 0);
+    lv_obj_set_style_border_color(box, tc(TH_DANGER_PRESSED), 0);
     lv_obj_set_style_border_width(box, 2, 0);
     lv_obj_set_style_radius(box, 12, 0);
     lv_obj_set_style_pad_all(box, 0, 0);
@@ -177,7 +178,7 @@ void buildSystemScreen() {
     lv_obj_t *lbl_m = lv_label_create(box);
     char buf_m[256]; backendText(T(STR_FACTORY_RESET_MSG), buf_m, sizeof(buf_m));
     lv_label_set_text(lbl_m, buf_m);
-    lv_obj_set_style_text_color(lbl_m, lv_color_hex(0xc8d8f0), 0);
+    lv_obj_set_style_text_color(lbl_m, tc(TH_TEXT), 0);
     lv_obj_set_style_text_font(lbl_m, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(lbl_m, LV_TEXT_ALIGN_CENTER, 0);
     lv_label_set_long_mode(lbl_m, LV_LABEL_LONG_WRAP);
@@ -188,19 +189,19 @@ void buildSystemScreen() {
     lv_obj_t *btn_c = lv_btn_create(box);
     lv_obj_set_size(btn_c, 180, 44);
     lv_obj_set_pos(btn_c, 12, 184);
-    lv_obj_set_style_bg_color(btn_c, lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_bg_color(btn_c, lv_color_hex(0x1a2840), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_c, tc(TH_SURFACE), 0);
+    lv_obj_set_style_bg_color(btn_c, tc(TH_SURFACE_3), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_c, 8, 0);
     lv_obj_set_style_shadow_width(btn_c, 0, 0);
     lv_obj_set_style_border_width(btn_c, 1, 0);
-    lv_obj_set_style_border_color(btn_c, lv_color_hex(0x1a2840), 0);
+    lv_obj_set_style_border_color(btn_c, tc(TH_SURFACE_3), 0);
     lv_obj_add_event_cb(btn_c, [](lv_event_t *e){
       lv_obj_del(lv_obj_get_parent(lv_obj_get_parent(lv_event_get_target(e))));
     }, LV_EVENT_CLICKED, NULL);
     lv_obj_t *lbl_c = lv_label_create(btn_c);
     char buf_c[32]; strncpy(buf_c, T(STR_CANCEL), sizeof(buf_c)-1);
     lv_label_set_text(lbl_c, buf_c);
-    lv_obj_set_style_text_color(lbl_c, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(lbl_c, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(lbl_c, &lv_font_montserrat_ext_14, 0);
     lv_obj_align(lbl_c, LV_ALIGN_CENTER, 0, 0);
 
@@ -208,12 +209,12 @@ void buildSystemScreen() {
     lv_obj_t *btn_ok = lv_btn_create(box);
     lv_obj_set_size(btn_ok, 228, 44);
     lv_obj_set_pos(btn_ok, 200, 184);
-    lv_obj_set_style_bg_color(btn_ok, lv_color_hex(0x3a1010), 0);
-    lv_obj_set_style_bg_color(btn_ok, lv_color_hex(0x602020), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(btn_ok, tc(TH_DANGER_BG), 0);
+    lv_obj_set_style_bg_color(btn_ok, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
     lv_obj_set_style_radius(btn_ok, 8, 0);
     lv_obj_set_style_shadow_width(btn_ok, 0, 0);
     lv_obj_set_style_border_width(btn_ok, 1, 0);
-    lv_obj_set_style_border_color(btn_ok, lv_color_hex(0x602020), 0);
+    lv_obj_set_style_border_color(btn_ok, tc(TH_DANGER_PRESSED), 0);
     lv_obj_add_event_cb(btn_ok, [](lv_event_t *e){
       logSD("Factory Reset: erasing NVS flash partition");
       Serial.println("Factory Reset: erasing NVS flash partition");
@@ -229,7 +230,7 @@ void buildSystemScreen() {
     lv_obj_t *lbl_ok = lv_label_create(btn_ok);
     char buf_ok[48]; strncpy(buf_ok, T(STR_FACTORY_RESET_CONFIRM), sizeof(buf_ok)-1);
     lv_label_set_text(lbl_ok, buf_ok);
-    lv_obj_set_style_text_color(lbl_ok, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(lbl_ok, tc(TH_DANGER_TEXT), 0);
     lv_obj_set_style_text_font(lbl_ok, &lv_font_montserrat_ext_14, 0);
     lv_obj_align(lbl_ok, LV_ALIGN_CENTER, 0, 0);
   }, LV_EVENT_CLICKED, NULL);
@@ -247,14 +248,14 @@ void buildSystemScreen() {
   { lv_obj_t *lbl = lv_label_create(btn_reboot);
     char buf[32]; strncpy(buf, T(STR_BTN_REBOOT), sizeof(buf)-1);
     lv_label_set_text(lbl, buf);
-    lv_obj_set_style_text_color(lbl, lv_color_hex(0xc8d8f0), 0);
+    lv_obj_set_style_text_color(lbl, tc(TH_TEXT), 0);
     lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_14, 0);
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(lbl, LV_ALIGN_CENTER, 0, -7);
     lv_obj_t *sub = lv_label_create(btn_reboot);
     char sub_buf[32]; strncpy(sub_buf, T(STR_BTN_REBOOT_SUB), sizeof(sub_buf)-1);
     lv_label_set_text(sub, sub_buf);
-    lv_obj_set_style_text_color(sub, lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(sub, tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(sub, &lv_font_montserrat_ext_12, 0);
     lv_obj_set_style_text_align(sub, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_align(sub, LV_ALIGN_CENTER, 0, 9); }

--- a/src/ui/tag_display.cpp
+++ b/src/ui/tag_display.cpp
@@ -8,6 +8,7 @@
 #include "lang.h"
 #include "main_screen_helpers.h"
 #include "spool_flow.h"
+#include "theme.h"
 
 
 // ============================================================
@@ -15,15 +16,15 @@
 // ============================================================
 void clearTagDisplay() {
   lv_label_set_text(lbl_nfc_dot, LV_SYMBOL_BULLET);
-  lv_obj_set_style_text_color(lbl_nfc_dot, lv_color_hex(0xf0b838), 0);  // yellow = kein Tag
+  lv_obj_set_style_text_color(lbl_nfc_dot, tc(TH_WARNING), 0);  // yellow = kein Tag
   lv_label_set_text(lbl_status, T(STR_WAIT_SCAN));
-  lv_obj_set_style_text_color(lbl_status, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_status, tc(TH_WARNING), 0);
   lv_label_set_text(lbl_uid, "-");
   lv_label_set_text(lbl_tray_uuid, "-");
   lv_label_set_text(lbl_material, "-");
   lv_label_set_text(lbl_date, "-");
   lv_label_set_text(lbl_spoolman_id, "?");
-  lv_obj_set_style_text_color(lbl_spoolman_id, lv_color_hex(0xf0b838), 0);
+  lv_obj_set_style_text_color(lbl_spoolman_id, tc(TH_WARNING), 0);
   lv_label_set_text(lbl_color, "-");
   lv_label_set_text(lbl_temp, "-");
   lv_label_set_text(lbl_vendor, "-");

--- a/src/ui/theme.cpp
+++ b/src/ui/theme.cpp
@@ -1,0 +1,36 @@
+#include "theme.h"
+
+// Positional, in ThemeColor order. Kept positional rather than using
+// designated initialisers because the Arduino ESP32 core builds as gnu++11,
+// where those are a GCC extension rather than standard.
+//
+// These are the exact literals that were previously hardcoded at the call
+// sites, so the default palette is byte-for-byte the original look.
+uint32_t g_theme[] = {
+  0x0a1020,   // TH_BG
+  0x0a1828,   // TH_SURFACE
+  0x1a3060,   // TH_SURFACE_2
+  0x1a2840,   // TH_SURFACE_3
+  0x1a2030,   // TH_SURFACE_DARK
+  0x0a1e30,   // TH_TILE_BG
+  0x1a3050,   // TH_BORDER
+  0x28d49a,   // TH_ACCENT
+  0xc8d8f0,   // TH_TEXT
+  0xe8f0ff,   // TH_TEXT_BRIGHT
+  0x4a6fa0,   // TH_TEXT_MUTED
+  0x2a4060,   // TH_TEXT_DIM
+  0xf0b838,   // TH_WARNING
+  0x40c080,   // TH_SUCCESS_TEXT
+  0x2a5030,   // TH_SUCCESS_BG
+  0x1a3020,   // TH_OK_BG
+  0xff8080,   // TH_DANGER_TEXT
+  0x3a1010,   // TH_DANGER_BG
+  0x602020,   // TH_DANGER_PRESSED
+  0x000000,   // TH_BLACK
+};
+
+// Declared without an explicit size above so the compiler deduces it, then
+// checked here. Written as g_theme[TH_COUNT] a short initialiser would zero-fill
+// silently and the missing colours would render black.
+static_assert(sizeof(g_theme) / sizeof(g_theme[0]) == TH_COUNT,
+              "g_theme needs one entry per ThemeColor");

--- a/src/ui/theme.h
+++ b/src/ui/theme.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <lvgl.h>
+#include <stdint.h>
+
+// Runtime palette.
+//
+// Every entry is initialised to exactly the literal it replaced, so introducing
+// this table changes no pixel. It only moves the colours out of compile-time
+// constants and into something that can be changed at runtime, which is what
+// any kind of theme selection needs.
+//
+// Names describe the role a colour plays rather than the colour itself, so an
+// alternative palette can reuse them without the names becoming lies.
+enum ThemeColor : uint8_t {
+  TH_BG,              // page background
+  TH_SURFACE,         // header bar, back/close button face
+  TH_SURFACE_2,       // raised buttons, sliders, list rows
+  TH_SURFACE_3,       // alternate raised surface
+  TH_SURFACE_DARK,    // recessed surface
+  TH_TILE_BG,         // settings tile face
+  TH_BORDER,          // tile borders and pressed state
+  TH_ACCENT,          // primary accent: titles, icons, active states
+  TH_TEXT,            // primary body text
+  TH_TEXT_BRIGHT,     // emphasised text
+  TH_TEXT_MUTED,      // subtitles
+  TH_TEXT_DIM,        // hints, least emphasis
+  TH_WARNING,         // amber status line
+  TH_SUCCESS_TEXT,
+  TH_SUCCESS_BG,
+  TH_OK_BG,
+  TH_DANGER_TEXT,
+  TH_DANGER_BG,
+  TH_DANGER_PRESSED,
+  TH_BLACK,
+  TH_COUNT
+};
+
+extern uint32_t g_theme[TH_COUNT];
+
+// Shorthand used at the call sites in place of lv_color_hex(0x......).
+static inline lv_color_t tc(ThemeColor c) { return lv_color_hex(g_theme[c]); }

--- a/src/ui/ui_common.cpp
+++ b/src/ui/ui_common.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 
 #include "hardware/sd_logger.h"
+#include "theme.h"
 
 
 lv_color_t swatchColorFromHex(const char* hex) {
@@ -22,14 +23,14 @@ lv_obj_t* addInfoRow(lv_obj_t* parent, int y, const char* label,
                      lv_obj_t** out_label) {
   lv_obj_t *l = lv_label_create(parent);
   lv_label_set_text(l, label);
-  lv_obj_set_style_text_color(l, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(l, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_14, 0);
   lv_obj_set_pos(l, INFO_ROW_LABEL_X, y + 3);
   if (out_label) *out_label = l;
 
   lv_obj_t *v = lv_label_create(parent);
   lv_label_set_text(v, "-");
-  lv_obj_set_style_text_color(v, lv_color_hex(0xe8f0ff), 0);
+  lv_obj_set_style_text_color(v, tc(TH_TEXT_BRIGHT), 0);
   lv_obj_set_style_text_font(v, &lv_font_montserrat_ext_16, 0);
   lv_label_set_long_mode(v, LV_LABEL_LONG_DOT);
   lv_obj_set_width(v, INFO_ROW_VALUE_W);
@@ -41,23 +42,23 @@ lv_obj_t* makeListBtn(lv_obj_t* list, const char* ico_sym, const char* title,
                       const char* sub, bool toggle_active) {
   lv_obj_t *btn = lv_btn_create(list);
   lv_obj_set_size(btn, 456, 64);
-  lv_obj_set_style_bg_color(btn, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn, 10, 0);
   lv_obj_set_style_shadow_width(btn, 0, 0);
   lv_obj_set_style_border_width(btn, 1, 0);
-  lv_obj_set_style_border_color(btn, toggle_active ? lv_color_hex(0x28d49a) : lv_color_hex(0x1a3050), 0);
+  lv_obj_set_style_border_color(btn, toggle_active ? tc(TH_ACCENT) : tc(TH_BORDER), 0);
   lv_obj_set_style_pad_all(btn, 0, 0);
 
   lv_obj_t *ico = lv_label_create(btn);
   lv_label_set_text(ico, ico_sym);
-  lv_obj_set_style_text_color(ico, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(ico, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(ico, &lv_font_montserrat_ext_20, 0);
   lv_obj_align(ico, LV_ALIGN_LEFT_MID, 14, 0);
 
   lv_obj_t *lbl = lv_label_create(btn);
   lv_label_set_text(lbl, title);
-  lv_obj_set_style_text_color(lbl, lv_color_hex(0xe8f0ff), 0);
+  lv_obj_set_style_text_color(lbl, tc(TH_TEXT_BRIGHT), 0);
   lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_16, 0);
   lv_obj_set_width(lbl, 320);
   lv_obj_align(lbl, LV_ALIGN_LEFT_MID, 52, sub && strlen(sub) > 0 ? -10 : 0);
@@ -65,7 +66,7 @@ lv_obj_t* makeListBtn(lv_obj_t* list, const char* ico_sym, const char* title,
   if (sub && strlen(sub) > 0) {
     lv_obj_t *slbl = lv_label_create(btn);
     lv_label_set_text(slbl, sub);
-    lv_obj_set_style_text_color(slbl, toggle_active ? lv_color_hex(0x28d49a) : lv_color_hex(0x4a6fa0), 0);
+    lv_obj_set_style_text_color(slbl, toggle_active ? tc(TH_ACCENT) : tc(TH_TEXT_MUTED), 0);
     lv_obj_set_style_text_font(slbl, &lv_font_montserrat_ext_12, 0);
     lv_obj_set_width(slbl, 320);
     lv_obj_align(slbl, LV_ALIGN_LEFT_MID, 52, 12);
@@ -73,7 +74,7 @@ lv_obj_t* makeListBtn(lv_obj_t* list, const char* ico_sym, const char* title,
 
   lv_obj_t *arr = lv_label_create(btn);
   lv_label_set_text(arr, LV_SYMBOL_RIGHT);
-  lv_obj_set_style_text_color(arr, lv_color_hex(0x2a4060), 0);
+  lv_obj_set_style_text_color(arr, tc(TH_TEXT_DIM), 0);
   lv_obj_set_style_text_font(arr, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(arr, LV_ALIGN_RIGHT_MID, -14, 0);
   return btn;
@@ -83,8 +84,8 @@ void addBackButton(lv_obj_t *parent, lv_event_cb_t cb) {
   lv_obj_t *btn = lv_btn_create(parent);
   lv_obj_set_size(btn, 44, 44);
   lv_obj_align(btn, LV_ALIGN_TOP_LEFT, 4, 2);
-  lv_obj_set_style_bg_color(btn, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn, 8, 0);
   lv_obj_set_style_shadow_width(btn, 0, 0);
   lv_obj_set_style_border_width(btn, 0, 0);
@@ -92,7 +93,7 @@ void addBackButton(lv_obj_t *parent, lv_event_cb_t cb) {
   lv_obj_t *lbl = lv_label_create(btn);
   lv_label_set_text(lbl, LV_SYMBOL_LEFT);
   lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_18, 0);
-  lv_obj_set_style_text_color(lbl, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl, tc(TH_ACCENT), 0);
   lv_obj_center(lbl);
 }
 
@@ -100,8 +101,8 @@ void addCloseButton(lv_obj_t *parent) {
   lv_obj_t *btn = lv_btn_create(parent);
   lv_obj_set_size(btn, 44, 44);
   lv_obj_align(btn, LV_ALIGN_TOP_RIGHT, -4, 2);
-  lv_obj_set_style_bg_color(btn, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn, 8, 0);
   lv_obj_set_style_shadow_width(btn, 0, 0);
   lv_obj_set_style_border_width(btn, 0, 0);
@@ -109,7 +110,7 @@ void addCloseButton(lv_obj_t *parent) {
   lv_obj_t *lbl = lv_label_create(btn);
   lv_label_set_text(lbl, LV_SYMBOL_CLOSE);
   lv_obj_set_style_text_font(lbl, &lv_font_montserrat_ext_18, 0);
-  lv_obj_set_style_text_color(lbl, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl, tc(TH_DANGER_TEXT), 0);
   lv_obj_center(lbl);
 }
 
@@ -120,7 +121,7 @@ void buildSubHeader(lv_obj_t *parent, const char *title,
 
   lv_obj_t *lbl_title = lv_label_create(parent);
   lv_label_set_text(lbl_title, title);
-  lv_obj_set_style_text_color(lbl_title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(lbl_title, LV_ALIGN_TOP_MID, 0, 12);
 
@@ -142,6 +143,6 @@ lv_obj_t* buildOverlayScreen() {
   lv_obj_set_style_border_width(scr, 0, 0);
   lv_obj_set_style_pad_all(scr, 0, 0);
   lv_obj_clear_flag(scr, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr, tc(TH_BG), 0);
   return scr;
 }

--- a/src/ui/update_badges.cpp
+++ b/src/ui/update_badges.cpp
@@ -3,15 +3,17 @@
 #include "services/ota_state.h"
 
 #include <lvgl.h>
+#include "theme.h"
 
 
 namespace {
 constexpr int BADGE_SIZE   = 14;
 constexpr int BADGE_BORDER = 2;
-// Drawn in the screen background colour, so the dot keeps a clean rim where it
-// overlaps the button underneath.
-constexpr uint32_t BADGE_COLOR        = 0xe03030;
-constexpr uint32_t BADGE_BORDER_COLOR = 0x0a1020;
+constexpr uint32_t BADGE_COLOR = 0xe03030;
+// The rim is drawn in the screen background colour so the dot keeps a clean
+// edge over the button underneath. Read at the point of use: the palette is a
+// runtime value, so a constexpr cannot hold it and a static would capture
+// whatever the colour was when the first badge was built.
 }  // namespace
 
 
@@ -28,7 +30,7 @@ lv_obj_t* createUpdateBadge(lv_obj_t* parent, lv_obj_t* anchor) {
   lv_obj_set_size(badge, BADGE_SIZE, BADGE_SIZE);
   lv_obj_set_style_radius(badge, BADGE_SIZE / 2, 0);
   lv_obj_set_style_bg_color(badge, lv_color_hex(BADGE_COLOR), 0);
-  lv_obj_set_style_border_color(badge, lv_color_hex(BADGE_BORDER_COLOR), 0);
+  lv_obj_set_style_border_color(badge, tc(TH_BG), 0);
   lv_obj_set_style_border_width(badge, BADGE_BORDER, 0);
   lv_obj_set_style_pad_all(badge, 0, 0);
   lv_obj_clear_flag(badge, LV_OBJ_FLAG_SCROLLABLE);

--- a/src/ui/wifi_info.cpp
+++ b/src/ui/wifi_info.cpp
@@ -14,6 +14,7 @@
 #include "services/user_options.h"
 #include "services/wifi_manager.h"
 #include "ui_common.h"
+#include "theme.h"
 
 // One fact per row, label and value in two columns across the full width, so
 // nothing has to wrap and every row stays on its own baseline.
@@ -66,13 +67,13 @@ static void refreshIpBarButton() {
   if (!btn_ipbar || !lv_obj_is_valid(btn_ipbar)) return;
   const bool on = (g_ip_bar_mode != IP_BAR_OFF);
   lv_obj_set_style_border_color(btn_ipbar,
-    lv_color_hex(on ? 0x28d49a : 0x1a3050), 0);
+    lv_color_hex(on ? g_theme[TH_ACCENT] : g_theme[TH_BORDER]), 0);
   if (lbl_ipbar_mode) {
     char buf[24];
     ipBarModeText(buf, sizeof(buf));
     lv_label_set_text(lbl_ipbar_mode, buf);
     lv_obj_set_style_text_color(lbl_ipbar_mode,
-      lv_color_hex(on ? 0x28d49a : 0x4a6fa0), 0);
+      lv_color_hex(on ? g_theme[TH_ACCENT] : g_theme[TH_TEXT_MUTED]), 0);
   }
 }
 
@@ -88,8 +89,8 @@ static void buildIpBarSelector() {
   btn_ipbar = lv_btn_create(scr_wifi);
   lv_obj_set_size(btn_ipbar, 456, 44);
   lv_obj_set_pos(btn_ipbar, 12, SELECTOR_Y);
-  lv_obj_set_style_bg_color(btn_ipbar, lv_color_hex(0x0a1e30), 0);
-  lv_obj_set_style_bg_color(btn_ipbar, lv_color_hex(0x1a3050), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_ipbar, tc(TH_TILE_BG), 0);
+  lv_obj_set_style_bg_color(btn_ipbar, tc(TH_BORDER), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_ipbar, 10, 0);
   lv_obj_set_style_shadow_width(btn_ipbar, 0, 0);
   lv_obj_set_style_border_width(btn_ipbar, 1, 0);
@@ -100,7 +101,7 @@ static void buildIpBarSelector() {
     strncpy(buf, T(STR_BTN_IP_STATUSBAR), sizeof(buf) - 1);
     buf[sizeof(buf) - 1] = '\0';
     lv_label_set_text(title, buf); }
-  lv_obj_set_style_text_color(title, lv_color_hex(0xe8f0ff), 0);
+  lv_obj_set_style_text_color(title, tc(TH_TEXT_BRIGHT), 0);
   lv_obj_set_style_text_font(title, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(title, LV_ALIGN_LEFT_MID, 12, 0);
 
@@ -166,12 +167,12 @@ void updateWifiInfo() {
   // this" - the value still matters, it says which network is set up.
   lv_label_set_text(val_ssid, cfg_wifi_ssid[0] ? cfg_wifi_ssid : "-");
   lv_obj_set_style_text_color(val_ssid,
-    lv_color_hex(wifi_ok ? 0xe8f0ff : 0x4a6fa0), 0);
+    lv_color_hex(wifi_ok ? g_theme[TH_TEXT_BRIGHT] : g_theme[TH_TEXT_MUTED]), 0);
 
   lv_label_set_text(val_state, wifi_ok ? T(STR_WIFI_STATUS_CONNECTED)
                                        : T(STR_WIFI_STATUS_DISCONNECTED));
   lv_obj_set_style_text_color(val_state,
-    lv_color_hex(wifi_ok ? 0x40c080 : 0xff8080), 0);
+    lv_color_hex(wifi_ok ? g_theme[TH_SUCCESS_TEXT] : g_theme[TH_DANGER_TEXT]), 0);
 
   // The MAC belongs to the radio, not to the link, so it stays readable while
   // disconnected - that is exactly when someone is setting up a reservation.

--- a/src/ui/wifi_setup_screen.cpp
+++ b/src/ui/wifi_setup_screen.cpp
@@ -17,6 +17,7 @@
 #include "setup_welcome_screen.h"
 #include "ui_common.h"
 #include "services/backend.h"
+#include "theme.h"
 
 
 
@@ -79,12 +80,12 @@ void buildWifiSetupScreen() {
   lv_obj_set_style_border_width(scr_wifi_setup, 0, 0);
   lv_obj_set_style_pad_all(scr_wifi_setup, 0, 0);
   lv_obj_clear_flag(scr_wifi_setup, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr_wifi_setup, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_wifi_setup, tc(TH_BG), 0);
 
   // Header
   lv_obj_t *title = lv_label_create(scr_wifi_setup);
   lv_label_set_text(title, T(STR_WIFI_TITLE));
-  lv_obj_set_style_text_color(title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 14);
 
@@ -106,14 +107,14 @@ void buildWifiSetupScreen() {
   lv_obj_t *btn_scan = lv_btn_create(scr_wifi_setup);
   lv_obj_set_size(btn_scan, 44, 36);
   lv_obj_align(btn_scan, LV_ALIGN_TOP_MID, 100, 4);
-  lv_obj_set_style_bg_color(btn_scan, lv_color_hex(0x0a1828), 0);
-  lv_obj_set_style_bg_color(btn_scan, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_scan, tc(TH_SURFACE), 0);
+  lv_obj_set_style_bg_color(btn_scan, tc(TH_SURFACE_2), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_scan, 6, 0);
   lv_obj_set_style_shadow_width(btn_scan, 0, 0);
   lv_obj_set_style_border_width(btn_scan, 0, 0);
   lv_obj_t *lbl_scan_btn = lv_label_create(btn_scan);
   lv_label_set_text(lbl_scan_btn, LV_SYMBOL_REFRESH);
-  lv_obj_set_style_text_color(lbl_scan_btn, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(lbl_scan_btn, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(lbl_scan_btn, &lv_font_montserrat_ext_18, 0);
   lv_obj_center(lbl_scan_btn);
 
@@ -121,7 +122,7 @@ void buildWifiSetupScreen() {
   lv_obj_t *list = lv_obj_create(scr_wifi_setup);
   lv_obj_set_size(list, 460, 218);
   lv_obj_set_pos(list, 10, 56);
-  lv_obj_set_style_bg_color(list, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(list, tc(TH_BG), 0);
   lv_obj_set_style_border_width(list, 0, 0);
   lv_obj_set_style_pad_all(list, 2, 0);
   lv_obj_set_style_radius(list, 0, 0);
@@ -134,7 +135,7 @@ void buildWifiSetupScreen() {
   // Status label (initially "scanning...")
   lbl_wifi_setup_status = lv_label_create(scr_wifi_setup);
   lv_label_set_text(lbl_wifi_setup_status, T(STR_WIFI_SCAN));
-  lv_obj_set_style_text_color(lbl_wifi_setup_status, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_wifi_setup_status, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_wifi_setup_status, &lv_font_montserrat_ext_14, 0);
   lv_obj_align(lbl_wifi_setup_status, LV_ALIGN_BOTTOM_MID, 0, -8);
 
@@ -211,18 +212,18 @@ void doWifiScan() {
 
     // Signal color
     uint32_t sig_color;
-    if      (rssi >= -65) sig_color = 0x28d49a;  // green
-    else if (rssi >= -80) sig_color = 0xf0b838;  // yellow
+    if      (rssi >= -65) sig_color = g_theme[TH_ACCENT];  // green
+    else if (rssi >= -80) sig_color = g_theme[TH_WARNING];  // yellow
     else                  sig_color = 0xff8000;   // orange
 
     // Row button
     lv_obj_t *row = lv_btn_create(lbl_wifi_scan_list);
     lv_obj_set_size(row, 452, 46);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x0a1828), 0);
-    lv_obj_set_style_bg_color(row, lv_color_hex(0x1a3060), LV_STATE_PRESSED);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE), 0);
+    lv_obj_set_style_bg_color(row, tc(TH_SURFACE_2), LV_STATE_PRESSED);
     lv_obj_set_style_radius(row, 6, 0);
     lv_obj_set_style_shadow_width(row, 0, 0);
-    lv_obj_set_style_border_color(row, lv_color_hex(0x1a2840), 0);
+    lv_obj_set_style_border_color(row, tc(TH_SURFACE_3), 0);
     lv_obj_set_style_border_width(row, 1, 0);
     lv_obj_set_style_pad_all(row, 0, 0);
     lv_obj_set_user_data(row, row_ssid[slot]);
@@ -230,7 +231,7 @@ void doWifiScan() {
     // SSID Label
     lv_obj_t *lbl_ssid = lv_label_create(row);
     lv_label_set_text(lbl_ssid, ssid.c_str());
-    lv_obj_set_style_text_color(lbl_ssid, lv_color_hex(0xe8f0ff), 0);
+    lv_obj_set_style_text_color(lbl_ssid, tc(TH_TEXT_BRIGHT), 0);
     lv_obj_set_style_text_font(lbl_ssid, &lv_font_montserrat_ext_16, 0);
     lv_obj_align(lbl_ssid, LV_ALIGN_LEFT_MID, 12, 0);
     lv_label_set_long_mode(lbl_ssid, LV_LABEL_LONG_DOT);
@@ -284,7 +285,7 @@ void buildWifiPassScreen() {
   lv_obj_set_style_border_width(scr_wifi_pass, 0, 0);
   lv_obj_set_style_pad_all(scr_wifi_pass, 0, 0);
   lv_obj_clear_flag(scr_wifi_pass, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr_wifi_pass, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_wifi_pass, tc(TH_BG), 0);
 
   // Back button
   addBackButton(scr_wifi_pass, [](lv_event_t *e) { showWifiSetupScreen(); });
@@ -293,7 +294,7 @@ void buildWifiPassScreen() {
   // Title
   lv_obj_t *title = lv_label_create(scr_wifi_pass);
   lv_label_set_text(title, T(STR_WIFI_PASS_TITLE));
-  lv_obj_set_style_text_color(title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 14);
 
@@ -302,7 +303,7 @@ void buildWifiPassScreen() {
   snprintf(ssid_hint, sizeof(ssid_hint), T(STR_WIFI_PASS_HINT), wifi_setup_ssid);
   lv_obj_t *lbl_ssid_show = lv_label_create(scr_wifi_pass);
   lv_label_set_text(lbl_ssid_show, ssid_hint);
-  lv_obj_set_style_text_color(lbl_ssid_show, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_ssid_show, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_ssid_show, &lv_font_montserrat_ext_14, 0);
   lv_obj_align(lbl_ssid_show, LV_ALIGN_TOP_MID, 0, 52);
 
@@ -379,7 +380,7 @@ void showWifiConnectingScreen() {
     char ok_buf[48];
     snprintf(ok_buf, sizeof(ok_buf), LV_SYMBOL_OK "  %s", T(STR_WIFI_SUCCESS));
     if (status_lbl) lv_label_set_text(status_lbl, ok_buf);
-    lv_obj_set_style_text_color(status_lbl, lv_color_hex(0x28d49a), 0);
+    lv_obj_set_style_text_color(status_lbl, tc(TH_ACCENT), 0);
 
     if (conn_val_ssid) {
       lv_label_set_text(conn_val_ssid, cfg_wifi_ssid[0] ? cfg_wifi_ssid : "-");
@@ -404,7 +405,7 @@ void showWifiConnectingScreen() {
     char fail_buf[80];
     snprintf(fail_buf, sizeof(fail_buf), T(STR_WIFI_CONN_FAILED), cfg_wifi_ssid);
     if (status_lbl) lv_label_set_text(status_lbl, fail_buf);
-    lv_obj_set_style_text_color(status_lbl, lv_color_hex(0xff8080), 0);
+    lv_obj_set_style_text_color(status_lbl, tc(TH_DANGER_TEXT), 0);
 
     // Show retry button
     if (btn_conn_retry) lv_obj_clear_flag(btn_conn_retry, LV_OBJ_FLAG_HIDDEN);
@@ -429,11 +430,11 @@ void buildWifiConnectingScreen() {
   lv_obj_set_style_border_width(scr_wifi_connecting, 0, 0);
   lv_obj_set_style_pad_all(scr_wifi_connecting, 0, 0);
   lv_obj_clear_flag(scr_wifi_connecting, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_style_bg_color(scr_wifi_connecting, lv_color_hex(0x0a1020), 0);
+  lv_obj_set_style_bg_color(scr_wifi_connecting, tc(TH_BG), 0);
 
   lv_obj_t *title = lv_label_create(scr_wifi_connecting);
   lv_label_set_text(title, T(STR_WIFI_TITLE));
-  lv_obj_set_style_text_color(title, lv_color_hex(0x28d49a), 0);
+  lv_obj_set_style_text_color(title, tc(TH_ACCENT), 0);
   lv_obj_set_style_text_font(title, &lv_font_montserrat_ext_18, 0);
   lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 24);
 
@@ -444,7 +445,7 @@ void buildWifiConnectingScreen() {
   snprintf(conn_buf, sizeof(conn_buf), T(STR_WIFI_CONNECTING), wifi_setup_ssid);
   lv_obj_t *lbl_connecting = lv_label_create(scr_wifi_connecting);
   lv_label_set_text(lbl_connecting, conn_buf);
-  lv_obj_set_style_text_color(lbl_connecting, lv_color_hex(0x4a6fa0), 0);
+  lv_obj_set_style_text_color(lbl_connecting, tc(TH_TEXT_MUTED), 0);
   lv_obj_set_style_text_font(lbl_connecting, &lv_font_montserrat_ext_16, 0);
   lv_obj_align(lbl_connecting, LV_ALIGN_TOP_MID, 0, 68);
 
@@ -452,7 +453,7 @@ void buildWifiConnectingScreen() {
   lbl_conn_status = lv_label_create(scr_wifi_connecting);
   lv_obj_t *lbl_status_conn = lbl_conn_status;
   lv_label_set_text(lbl_status_conn, "");
-  lv_obj_set_style_text_color(lbl_status_conn, lv_color_hex(0xc8d8f0), 0);
+  lv_obj_set_style_text_color(lbl_status_conn, tc(TH_TEXT), 0);
   lv_obj_set_style_text_font(lbl_status_conn, &lv_font_montserrat_ext_20, 0);
   lv_obj_set_style_text_align(lbl_status_conn, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(lbl_status_conn, LV_ALIGN_TOP_MID, 0, 100);
@@ -477,15 +478,15 @@ void buildWifiConnectingScreen() {
   lv_obj_set_size(btn_retry, 200, 48);
   lv_obj_align(btn_retry, LV_ALIGN_BOTTOM_MID, -110, -20);
   lv_obj_add_flag(btn_retry, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_set_style_bg_color(btn_retry, lv_color_hex(0x3a1010), 0);
-  lv_obj_set_style_bg_color(btn_retry, lv_color_hex(0x602020), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_retry, tc(TH_DANGER_BG), 0);
+  lv_obj_set_style_bg_color(btn_retry, tc(TH_DANGER_PRESSED), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_retry, 8, 0);
   lv_obj_set_style_shadow_width(btn_retry, 0, 0);
   lv_obj_set_style_border_width(btn_retry, 0, 0);
   lv_obj_add_event_cb(btn_retry, [](lv_event_t *e) { logSD("BTN: Retry -> WifiSetup"); showWifiSetupScreen(); }, LV_EVENT_CLICKED, NULL);
   lv_obj_t *lbl_retry = lv_label_create(btn_retry);
   lv_label_set_text(lbl_retry, LV_SYMBOL_LEFT "  "); { char rb[32]; snprintf(rb,sizeof(rb),"%s",T(STR_RETRY)); lv_label_set_text(lbl_retry,rb); }
-  lv_obj_set_style_text_color(lbl_retry, lv_color_hex(0xff8080), 0);
+  lv_obj_set_style_text_color(lbl_retry, tc(TH_DANGER_TEXT), 0);
   lv_obj_set_style_text_font(lbl_retry, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_retry);
 
@@ -495,8 +496,8 @@ void buildWifiConnectingScreen() {
   lv_obj_set_size(btn_next, 200, 48);
   lv_obj_align(btn_next, LV_ALIGN_BOTTOM_MID, 110, -20);
   lv_obj_add_flag(btn_next, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_set_style_bg_color(btn_next, lv_color_hex(0x1a3020), 0);
-  lv_obj_set_style_bg_color(btn_next, lv_color_hex(0x2a5030), LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(btn_next, tc(TH_OK_BG), 0);
+  lv_obj_set_style_bg_color(btn_next, tc(TH_SUCCESS_BG), LV_STATE_PRESSED);
   lv_obj_set_style_radius(btn_next, 8, 0);
   lv_obj_set_style_shadow_width(btn_next, 0, 0);
   lv_obj_set_style_border_width(btn_next, 0, 0);
@@ -520,7 +521,7 @@ void buildWifiConnectingScreen() {
     size_t n = strlen(nb);
     snprintf(nb + n, sizeof(nb) - n, "  " LV_SYMBOL_RIGHT);
     lv_label_set_text(lbl_next, nb); }
-  lv_obj_set_style_text_color(lbl_next, lv_color_hex(0x40c080), 0);
+  lv_obj_set_style_text_color(lbl_next, tc(TH_SUCCESS_TEXT), 0);
   lv_obj_set_style_text_font(lbl_next, &lv_font_montserrat_ext_16, 0);
   lv_obj_center(lbl_next);
 }


### PR DESCRIPTION
> Rebased onto **v0.6.2-beta**, so the new screens from that release (remote link popup, FilaMan options, update badges) are converted too.

Every colour in the UI is a compile-time literal: **865** `lv_color_hex(0x......)` call sites across 38 files, with the accent green alone repeated more than 140 times. Nothing can change a colour at runtime because there is nothing to change.

This adds `src/ui/theme.{h,cpp}` — a `g_theme[]` table of 20 role-named entries plus a `tc()` shorthand — and points the call sites at it.

**This changes nothing on screen.** Every table entry is initialised to exactly the literal it replaced.

### Why role names

Tokens are named for the job a colour does, not the colour it is (`TH_BG`, `TH_ACCENT`, `TH_TEXT_MUTED`), so a different palette can reuse them without the names becoming lies.

### Two forms at the call sites

`lv_color_hex()` takes a `uint32_t`, so both spellings are needed:

```cpp
tc(TH_ACCENT)          // where an lv_color_t is wanted
g_theme[TH_ACCENT]     // inside a ternary, a struct field or a variable
```

### What is deliberately left alone

164 call sites are untouched. They are a long tail of one-off accents used three times or fewer, and folding them in would mean either ~70 more tokens or quietly consolidating colours that genuinely differ. Neither belongs in a change that claims to alter nothing.

### Guard

`g_theme[]` is declared without an explicit size so the compiler deduces it, with a `static_assert` against `TH_COUNT`. Written as `g_theme[TH_COUNT]` a short initialiser would zero-fill silently and the missing colours would render black.

### Verification

- All 20 tokens cross-checked against the literals they replaced — **zero mismatches**, so the no-op claim is mechanical, not eyeballed.
- Re-running the transform replaces nothing further (idempotent).
- Builds clean; flashed and run on a WT32-SC01 Plus.

Cost is 80 bytes of RAM, which is exactly the 20 `uint32_t`.

### Sequence

This is the first of four related changes. It stands alone and is safe to merge on its own — the rest build on it, but nothing here depends on them.

1. **this PR** — palette extraction (no-op)
2. #10 — remaining structural colours onto the palette
3. #11 — runtime theme: presets, UI gain, on-device picker
4. #12 — web UI restructure + browser theme editor

Happy to drop or rework any of the later ones; this one is the foundation they share.
