### PR TITLE
feat: derive the spool weight from a new spool instead of assuming it

### DIFF
--- a/src/ui/confirm_popup.cpp
+++ b/src/ui/confirm_popup.cpp
@@ -1,4 +1,5 @@
 #include "confirm_popup.h"
+#include <math.h>
 #include "app/app_state.h"
 
 #include <Arduino.h>
@@ -26,6 +27,114 @@ void closeConfirmPopup() {
   confirm_action = 0;
   lbl_auto_weight_btn = nullptr;  // Pointer ungültig nach lv_obj_del
 }
+
+
+// The weight the scope buttons below will store. Normally whatever is on the
+// pad, but a brand new spool can derive it instead -- see the New spool button.
+static float s_tare_prompt_g = 0.0f;
+static bool  s_tare_then_new = false;
+
+// After a tare is stored from the New spool flow the initial weight follows
+// from it: what is left of the reading once the spool itself is taken off.
+// Done here rather than in the caller so the two writes stay in the order that
+// makes the second one correct.
+static void tareFollowUp() {
+  if (!s_tare_then_new) return;
+  s_tare_then_new = false;
+  float initial = scale_weight_g - s_tare_prompt_g;
+  if (initial < 0) initial = 0;
+  patchInitialWeight(initial);
+}
+
+static void showSpoolWeightPopup(float grams, bool then_new_spool) {
+  s_tare_prompt_g = grams;
+  s_tare_then_new = then_new_spool;
+
+      // Sub-popup: where should the spool weight be written?
+      const float w = s_tare_prompt_g;
+
+      lv_obj_t *popup = lv_obj_create(lv_scr_act());
+      lv_obj_set_size(popup, 480, 320);
+      lv_obj_set_pos(popup, 0, 0);
+      lv_obj_set_style_bg_color(popup, lv_color_hex(0x0a1020), 0);
+      lv_obj_set_style_bg_opa(popup, LV_OPA_COVER, 0);
+      lv_obj_set_style_border_width(popup, 0, 0);
+      lv_obj_set_style_pad_all(popup, 0, 0);
+      lv_obj_clear_flag(popup, LV_OBJ_FLAG_SCROLLABLE);
+
+      // Title
+      lv_obj_t *title = lv_label_create(popup);
+      char title_buf[48];
+      snprintf(title_buf, sizeof(title_buf), T(STR_SPOOL_WEIGHT_TITLE), w);
+      lv_label_set_text(title, title_buf);
+      lv_obj_set_style_text_color(title, lv_color_hex(0x28d49a), 0);
+      lv_obj_set_style_text_font(title, &lv_font_montserrat_ext_14, 0);
+      lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 10);
+
+      // Button 1: this spool
+      lv_obj_t *b1 = lv_btn_create(popup);
+      lv_obj_set_size(b1, 460, 60); lv_obj_set_pos(b1, 10, 36);
+      lv_obj_set_style_bg_color(b1, lv_color_hex(0x0a2040), 0);
+      lv_obj_set_style_radius(b1, 8, 0); lv_obj_set_style_shadow_width(b1, 0, 0);
+      { lv_obj_t *l = lv_label_create(b1);
+        lv_label_set_text(l, T(STR_BTN_THIS_SPOOL));
+        lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
+        lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
+        lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
+        lv_obj_center(l); }
+      lv_obj_add_event_cb(b1, [](lv_event_t *e) {
+        patchSpoolWeight(s_tare_prompt_g); tareFollowUp();
+        lv_obj_del(lv_obj_get_parent(lv_event_get_target(e)));
+      }, LV_EVENT_CLICKED, NULL);
+
+      // Button 2: this filament
+      lv_obj_t *b2 = lv_btn_create(popup);
+      lv_obj_set_size(b2, 460, 60); lv_obj_set_pos(b2, 10, 106);
+      lv_obj_set_style_bg_color(b2, lv_color_hex(0x0a2820), 0);
+      lv_obj_set_style_radius(b2, 8, 0); lv_obj_set_style_shadow_width(b2, 0, 0);
+      { lv_obj_t *l = lv_label_create(b2);
+        lv_label_set_text(l, T(STR_BTN_THIS_FILAMENT));
+        lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
+        lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
+        lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
+        lv_obj_center(l); }
+      lv_obj_add_event_cb(b2, [](lv_event_t *e) {
+        patchFilamentSpoolWeight(s_tare_prompt_g); tareFollowUp();
+        lv_obj_del(lv_obj_get_parent(lv_event_get_target(e)));
+      }, LV_EVENT_CLICKED, NULL);
+
+      // Button 3: vendor
+      lv_obj_t *b3 = lv_btn_create(popup);
+      lv_obj_set_size(b3, 460, 60); lv_obj_set_pos(b3, 10, 176);
+      lv_obj_set_style_bg_color(b3, lv_color_hex(0x281a00), 0);
+      lv_obj_set_style_radius(b3, 8, 0); lv_obj_set_style_shadow_width(b3, 0, 0);
+      { lv_obj_t *l = lv_label_create(b3);
+        lv_label_set_text(l, T(STR_BTN_THIS_VENDOR));
+        lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
+        lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
+        lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
+        lv_obj_center(l); }
+      lv_obj_add_event_cb(b3, [](lv_event_t *e) {
+        patchVendorSpoolWeight(s_tare_prompt_g); tareFollowUp();
+        lv_obj_del(lv_obj_get_parent(lv_event_get_target(e)));
+      }, LV_EVENT_CLICKED, NULL);
+
+      // Button 4: cancel
+      lv_obj_t *b4 = lv_btn_create(popup);
+      lv_obj_set_size(b4, 460, 40); lv_obj_set_pos(b4, 10, 256);
+      lv_obj_set_style_bg_color(b4, lv_color_hex(0x3a1010), 0);
+      lv_obj_set_style_radius(b4, 8, 0); lv_obj_set_style_shadow_width(b4, 0, 0);
+      { lv_obj_t *l = lv_label_create(b4);
+        lv_label_set_text(l, T(STR_CANCEL));
+        lv_obj_set_style_text_color(l, lv_color_hex(0xff8080), 0);
+        lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_14, 0);
+        lv_obj_center(l); }
+      lv_obj_add_event_cb(b4, [](lv_event_t *e) {
+        s_tare_then_new = false;
+        lv_obj_del(lv_obj_get_parent(lv_event_get_target(e)));
+      }, LV_EVENT_CLICKED, NULL);
+
+    }
 
 void showConfirmPopup(const char* msg, int action) {
   closeConfirmPopup();
@@ -147,6 +256,18 @@ void showConfirmPopup(const char* msg, int action) {
     lv_obj_set_style_shadow_width(btn3, 0, 0);
     lv_obj_add_event_cb(btn3, [](lv_event_t *e) {
       closeConfirmPopup();
+      // Offered when nothing is stored yet or the stored value disagrees: a
+      // measurement should win over a default inherited from the filament or
+      // the brand. The bounds keep a half-used spool, or one whose nominal
+      // weight is wrong, from writing a nonsense tare.
+      const float derived = scale_weight_g - sm_total;
+      const bool  plausible = (sm_total > 0.0f) && (derived >= 30.0f) && (derived <= 600.0f);
+      const bool  disagrees = (sm_spool_weight <= 0.0f) ||
+                              (fabsf(derived - (float)sm_spool_weight) >= 10.0f);
+      if (plausible && disagrees) {
+        showSpoolWeightPopup(derived, true);   // stores the tare, then the initial
+        return;
+      }
       float initial = scale_weight_g - (float)sm_spool_weight;
       if (initial < 0) initial = 0;
       patchInitialWeight(initial);
@@ -170,89 +291,7 @@ void showConfirmPopup(const char* msg, int action) {
     lv_obj_set_style_shadow_width(btn4, 0, 0);
     lv_obj_add_event_cb(btn4, [](lv_event_t *e) {
       closeConfirmPopup();
-      // Sub-popup: where should the spool weight be written?
-      float w = scale_weight_g;
-
-      lv_obj_t *popup = lv_obj_create(lv_scr_act());
-      lv_obj_set_size(popup, 480, 320);
-      lv_obj_set_pos(popup, 0, 0);
-      lv_obj_set_style_bg_color(popup, lv_color_hex(0x0a1020), 0);
-      lv_obj_set_style_bg_opa(popup, LV_OPA_COVER, 0);
-      lv_obj_set_style_border_width(popup, 0, 0);
-      lv_obj_set_style_pad_all(popup, 0, 0);
-      lv_obj_clear_flag(popup, LV_OBJ_FLAG_SCROLLABLE);
-
-      // Title
-      lv_obj_t *title = lv_label_create(popup);
-      char title_buf[48];
-      snprintf(title_buf, sizeof(title_buf), T(STR_SPOOL_WEIGHT_TITLE), w);
-      lv_label_set_text(title, title_buf);
-      lv_obj_set_style_text_color(title, lv_color_hex(0x28d49a), 0);
-      lv_obj_set_style_text_font(title, &lv_font_montserrat_ext_14, 0);
-      lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 10);
-
-      // Button 1: this spool
-      lv_obj_t *b1 = lv_btn_create(popup);
-      lv_obj_set_size(b1, 460, 60); lv_obj_set_pos(b1, 10, 36);
-      lv_obj_set_style_bg_color(b1, lv_color_hex(0x0a2040), 0);
-      lv_obj_set_style_radius(b1, 8, 0); lv_obj_set_style_shadow_width(b1, 0, 0);
-      { lv_obj_t *l = lv_label_create(b1);
-        lv_label_set_text(l, T(STR_BTN_THIS_SPOOL));
-        lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
-        lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
-        lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
-        lv_obj_center(l); }
-      lv_obj_add_event_cb(b1, [](lv_event_t *e) {
-        patchSpoolWeight(scale_weight_g);
-        lv_obj_del(lv_obj_get_parent(lv_event_get_target(e)));
-      }, LV_EVENT_CLICKED, NULL);
-
-      // Button 2: this filament
-      lv_obj_t *b2 = lv_btn_create(popup);
-      lv_obj_set_size(b2, 460, 60); lv_obj_set_pos(b2, 10, 106);
-      lv_obj_set_style_bg_color(b2, lv_color_hex(0x0a2820), 0);
-      lv_obj_set_style_radius(b2, 8, 0); lv_obj_set_style_shadow_width(b2, 0, 0);
-      { lv_obj_t *l = lv_label_create(b2);
-        lv_label_set_text(l, T(STR_BTN_THIS_FILAMENT));
-        lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
-        lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
-        lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
-        lv_obj_center(l); }
-      lv_obj_add_event_cb(b2, [](lv_event_t *e) {
-        patchFilamentSpoolWeight(scale_weight_g);
-        lv_obj_del(lv_obj_get_parent(lv_event_get_target(e)));
-      }, LV_EVENT_CLICKED, NULL);
-
-      // Button 3: vendor
-      lv_obj_t *b3 = lv_btn_create(popup);
-      lv_obj_set_size(b3, 460, 60); lv_obj_set_pos(b3, 10, 176);
-      lv_obj_set_style_bg_color(b3, lv_color_hex(0x281a00), 0);
-      lv_obj_set_style_radius(b3, 8, 0); lv_obj_set_style_shadow_width(b3, 0, 0);
-      { lv_obj_t *l = lv_label_create(b3);
-        lv_label_set_text(l, T(STR_BTN_THIS_VENDOR));
-        lv_obj_set_style_text_color(l, lv_color_hex(0xc8d8f0), 0);
-        lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_16, 0);
-        lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_CENTER, 0);
-        lv_obj_center(l); }
-      lv_obj_add_event_cb(b3, [](lv_event_t *e) {
-        patchVendorSpoolWeight(scale_weight_g);
-        lv_obj_del(lv_obj_get_parent(lv_event_get_target(e)));
-      }, LV_EVENT_CLICKED, NULL);
-
-      // Button 4: cancel
-      lv_obj_t *b4 = lv_btn_create(popup);
-      lv_obj_set_size(b4, 460, 40); lv_obj_set_pos(b4, 10, 256);
-      lv_obj_set_style_bg_color(b4, lv_color_hex(0x3a1010), 0);
-      lv_obj_set_style_radius(b4, 8, 0); lv_obj_set_style_shadow_width(b4, 0, 0);
-      { lv_obj_t *l = lv_label_create(b4);
-        lv_label_set_text(l, T(STR_CANCEL));
-        lv_obj_set_style_text_color(l, lv_color_hex(0xff8080), 0);
-        lv_obj_set_style_text_font(l, &lv_font_montserrat_ext_14, 0);
-        lv_obj_center(l); }
-      lv_obj_add_event_cb(b4, [](lv_event_t *e) {
-        lv_obj_del(lv_obj_get_parent(lv_event_get_target(e)));
-      }, LV_EVENT_CLICKED, NULL);
-
+      showSpoolWeightPopup(scale_weight_g, false);
     }, LV_EVENT_CLICKED, NULL);
     lv_obj_t *l4 = lv_label_create(btn4);
     char buf4[56];


### PR DESCRIPTION
> **Independent of #9–#15.** Branched from `main`, mergeable in any order. Pairs naturally with #13 but doesn't depend on it.

**New spool** currently computes the filament weight by taking the stored spool weight off the reading:

```cpp
float initial = scale_weight_g - (float)sm_spool_weight;
patchInitialWeight(initial);
```

That is backwards for the one case where the button is pressed. A full spool has a **known** filament weight, which makes the spool weight the only unknown in the reading:

```
tare = measured − nominal filament
250 g = 1250 g − 1000 g
```

A sealed 1 kg spool reading 1250 g is telling you its spool weighs 250 g. That's a **measurement** — better than any catalogue figure or brand default, because it's this spool on this scale. It's also the only moment the device can take one without emptying the spool first, which is a wait of weeks.

### What changes

Pressing New spool now offers to store that number, at the same three scopes the existing spool-weight button already uses: **this spool / this filament / the brand**. The initial weight is written *afterwards*, derived from the tare just stored, so the two are consistent rather than the second contradicting the first.

The sub-popup is extracted rather than duplicated, so both entry points share one implementation and one set of scope buttons.

### Offered only when it would change something

- Nothing stored yet, **or** the stored value disagrees by ≥10 g
- A tare that already matches is left alone and the flow is exactly as before

### Bounded to 30–600 g

Outside that, the reading isn't a full spool of the expected filament — a half-used spool, or a nominal weight that's wrong — and a derived tare would be nonsense written to a filament or an entire brand. Better to fall back to the old path than to poison a brand default.

Cancelling writes **nothing at all**, including the initial weight, rather than leaving a half-applied state.

### It also fixes a real error

On a spool with **no** tare, the old path recorded the whole reading as filament. A 250 g spool was counted as filament for the rest of that spool's life, and every later percentage was computed against an initial weight that included the plastic. Silent, permanent, and invisible after the fact.

### Verification

Built and flashed on a WT32-SC01 Plus. One file, and the transform is reproducible from a clean checkout.
