### PR TITLE
fix: read a tag again when it is put back on the scale

### DIFF
--- a/src/app/app_loop.cpp
+++ b/src/app/app_loop.cpp
@@ -1102,13 +1102,22 @@ void appLoop() {
 
         Serial.printf("NFC: NTAG UID=%s\n", uid_str);
 
-        bool uid_changed_ntag_log = (strcmp(uid_str, g_tag.uid_str) != 0);
-        if (uid_changed_ntag_log) logSDf("NFC: NTAG UID=%s", uid_str);
+        // g_tag holds what is on screen, and the display deliberately keeps a
+        // spool for a minute after it is lifted. Asking it whether the tag
+        // changed therefore answers no for a tag that was taken off and put
+        // back inside that minute, and the whole read below is skipped.
+        //
+        // spoolman_queried_uid is the one that tracks the tag rather than the
+        // display: the removal handler clears it, with the comment "allow
+        // re-query when same tag is placed again". Until now nothing reached
+        // that check, because this one had already decided there was nothing
+        // to do.
+        bool uid_changed_ntag = (strcmp(uid_str, g_tag.uid_str) != 0) ||
+                                (strcmp(uid_str, spoolman_queried_uid) != 0);
+        if (uid_changed_ntag) logSDf("NFC: NTAG UID=%s", uid_str);
 
         lv_label_set_text(lbl_nfc_dot, LV_SYMBOL_BULLET);
         lv_obj_set_style_text_color(lbl_nfc_dot, lv_color_hex(0x28d49a), 0);
-
-        bool uid_changed_ntag = (strcmp(uid_str, g_tag.uid_str) != 0);
 
         if (uid_changed_ntag) {
           // New UID — clear old tag data


### PR DESCRIPTION
Take a spool off the scale and put it back within a minute and the scale does not read it again. No fresh lookup, no log line, and the screen keeps showing the figures from the previous scan — remaining weight, last dried, location. Anything the backend learned in between, or another device wrote, is not picked up.

## Why

The NTAG branch decides whether to read by asking `g_tag`:

```c
bool uid_changed_ntag = (strcmp(uid_str, g_tag.uid_str) != 0);
```

`g_tag` is display state. `clearTagDisplay()` empties it only after `NO_TAG_CLEAR_MS`, which is 60 s, because the display deliberately keeps showing a spool after it is lifted. So for that minute the comparison answers "unchanged" for a tag that genuinely left and came back, and the whole block below it is skipped.

The intent was already there. The removal handler does:

```c
spoolman_queried_uid[0] = '\0';  // allow re-query when same tag is placed again
```

Nothing ever reached that check — this comparison had already decided there was nothing to do.

## The change

Key the decision on the marker that tracks the tag rather than the display, alongside the existing one:

```c
bool uid_changed_ntag = (strcmp(uid_str, g_tag.uid_str) != 0) ||
                        (strcmp(uid_str, spoolman_queried_uid) != 0);
```

The separate `uid_changed_ntag_log` variable is gone; it computed the same thing one line earlier and had the same blind spot.

## Cost

None while a tag rests on the reader. `spoolman_queried_uid` is set immediately after the query, so every later poll takes the unchanged path exactly as before. A returning tag costs one lookup, which is the same as any newly presented tag and is the point of the fix.

Bambu tags are untouched — that branch has its own comparison against the block count.

## Verified on hardware

v0.7.0-beta.50 plus this commit, one NTAG lifted and replaced twice:

```
09:40:50  NFC: tag removed
09:40:52  NFC: NTAG UID=04:88:BF:4F:C9:2A:81
09:40:52  Spoolman: query tray_uuid=04:88:BF:4F:C9:2...
09:40:53  Spoolman: spool not found
09:40:55  NFC: tag removed
09:41:07  NFC: NTAG UID=04:88:BF:4F:C9:2A:81
09:41:07  Spoolman: query tray_uuid=04:88:BF:4F:C9:2...
```

Same UID both times. Before the change neither the detection line nor the query appeared on the return.

A tag has to be away for `NFC_ABSENT_NTAG_MS` (2.5 s) to count as removed, so a quick lift still changes nothing — the reading was never interrupted in that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
